### PR TITLE
Make permalinks relative

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ name: IIIF | International Image Interoperability Framework
 markdown: kramdown
 pygments: true
 exclude: [ dev.sh, publish.sh, README.md, vendor ]
+relative_permalinks: true
 kramdown:
   input: GFM
   parse_block_html: true


### PR DESCRIPTION
Make the site ready for Jekyll 2. 

> In Jekyll v1.0, we introduced absolute permalinks for pages in subdirectories. Until v2.0, it is opt-in. Starting with v2.0, however, absolute permalinks will become opt-out, meaning Jekyll will default to using absolute permalinks instead of relative permalinks.

Related to #101 
