### PR TITLE
Fix travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 # environment
 language: ruby
 rvm:
-  - 2.1
+  - "2.1"
 
 notifications:
   email:


### PR DESCRIPTION
According to http://lint.travis-ci.org/IIIF/iiif.io the `template` setting doesn’t exist for emails.
