### PR TITLE
re: #154. Use 'Change Log' throughout

### DIFF
--- a/source/api/annex/services/index.md
+++ b/source/api/annex/services/index.md
@@ -175,7 +175,7 @@ The production of this document was generously supported by a grant from the [An
 
 Thanks to the members of the [IIIF][iiif-community] for their continuous engagement, innovative ideas and feedback.
 
-### B. Changelog
+### B. Change Log
 
 | Date       | Description                                        |
 | ---------- | -------------------------------------------------- |

--- a/source/api/image/2.0/change-log.md
+++ b/source/api/image/2.0/change-log.md
@@ -1,5 +1,5 @@
 ---
-title: "Image API 2.0 Changelog"
+title: "Image API 2.0 Change Log"
 title_override: "Changes for IIIF Image API Version 2.0"
 id: image-api-20-changelog
 layout: sub-page

--- a/source/api/presentation/2.0/change-log.md
+++ b/source/api/presentation/2.0/change-log.md
@@ -1,5 +1,5 @@
 ---
-title: "Presentation API 2.0 Changelog"
+title: "Presentation API 2.0 Change Log"
 title_override: "Changes for IIIF Presentation API Version 2.0"
 id: presentation-api-20-changelog
 layout: sub-page

--- a/source/api/presentation/2.0/index.md
+++ b/source/api/presentation/2.0/index.md
@@ -1365,7 +1365,7 @@ The production of this document was generously supported by a grant from the [An
 
 Many thanks to Matthieu Bonicel, Tom Cramer, Ian Davis, Markus Enders, Renhart Gittens, Tim Gollins, Antoine Isaac, Neil Jefferies, Sean Martin, Roger Mathisen, Mark Patton, Petter Rønningsen, Raphael Schwemmer, Stuart Snydman and Simeon Warner for their thoughtful contributions. Thanks also to the members of the [IIIF][iiif-community] for their continuous engagement, innovative ideas and feedback.
 
-### E. ChangeLog
+### E. Change Log
 
 | Date       | Description                                        |
 | ---------- | -------------------------------------------------- |


### PR DESCRIPTION
We're not completely consistent yet with html IDs or reference links in the MarkDown, but the document text is now consistent.
