### PR TITLE
Added some more stuff to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,17 @@
 # Guidelines
 
-Follow the [branch-based workflow][flow].
+## Making Changes
+
+Please do not work on master. Submit pull requests from branches, and [squash your commits][squash] prior. For example:
+
+```
+ $ git checkout master 
+ $ git checkout pull # make sure you're up to date
+ $ git checkout my_cool_branch
+ $ git rebase -i master
+```
+
+and follow the prompts. Generally you'll `pick` the first commit and `squash` the rest into it.
 
 ## English
 
@@ -17,5 +28,19 @@ Use the [Kramdown syntax][kram].
 
 Images must be PNG.
 
-[flow]: https://guides.github.com/introduction/flow/
+## Front Matter
+
+ * Specs use `tags`, news and announements (`_posts`) use `categories`.
+ * Look at previous posts and specs to determine what tags/categories to use. 
+ * Anything in the `api` directory (and subdirectories thereof) must include the `spec-doc` tag.
+ * News posts must include:
+
+    * title
+    * author
+    * tags
+    * layout: post
+
+    and may include an excerpt.
+
 [kram]: http://kramdown.gettalong.org/syntax.html
+[squash]: http://lmgtfy.com/?q=Squash+git+commits


### PR DESCRIPTION
Should close #147

We can talk about this some more, but in general I think we just need to capture some conventions and requirements for making the site work. The one thing I added, which has become second nature to me, is the practice of squashing commits on branches. It's not bad once you're used to it, and it really does keep the history cleaner, which is only going to help us with change logs going forward.
