### PR TITLE
Make semantic versioning less specific to Image/Prezi API

### DIFF
--- a/source/api/annex/notes/semver.md
+++ b/source/api/annex/notes/semver.md
@@ -4,7 +4,7 @@ layout: spec
 tags: [annex, presentation-api, image-api]
 ---
 
-Starting with the 2.0.0 releases of both the IIIF [Image API][image-api] and [Presentation API][prezi-api], the specifications will follow [Semantic Versioning][semver] with version numbers of the form "MAJOR.MINOR.PATCH" where:
+Starting with the 2.0.0 releases of the IIIF [Image API][image-api] and [Presentation API][prezi-api], all future specifications will follow [Semantic Versioning][semver] with version numbers of the form "MAJOR.MINOR.PATCH" where:
 
   * MAJOR version increment indicates incompatible API changes.
   * MINOR version increment indicates addition of functionality in a backwards-compatible manner.
@@ -14,11 +14,11 @@ This versioning system will be implemented in the following ways:
 
   * URIs for the specifications will be updated with major and minor versions, with patch versions edited in place.
   * URIs for compliance and context documents will be updated with major versions only, and otherwise edited in place.
-  * The URI identifying the protocol (e.g. `http://iiif.io/api/image` for the IIIF [Image API][image-api]) does not change with versioning.
+  * URIs identifying a protocol (e.g. `http://iiif.io/api/image` for the IIIF [Image API][image-api]) will not change with versioning.
 
-In the case of the Image API, changes to either the API itself or the corresponding [compliance document][image-compliance] will increment the version number as appropriate. In all cases, major and minor releases will be accompanied by a change log, while changes in patch releases will be appended to the change log for the  latest major or minor release.
+In the case of the APIs with external compliance documents, changes to either the API itself or the corresponding compliance document (e.g. [image API compliance document]][image-compliance]) will increment the version number as appropriate. In all cases, major and minor releases will be accompanied by a change log, while changes in patch releases will be appended to the change log for the latest major or minor release.
 
-While the Presentation and Image APIs should always be compatible, it is not intended that their version numbers necessarily remain synchronized. A change in one API will not advance the version number of the other.
+While the APIs should always be consistent and compatible, it is not intended that version numbers will necessarily remain synchronized across the IIIF suite of APIs. A change in one API will not advance the version number of another.
 
 [semver]: http://semver.org/spec/v2.0.0.html "Semantic Versioning 2.0.0"
 [image-api]: /api/image/{{ site.image_api.latest.major }}.{{ site.image_api.latest.minor }}/ "Image API 2.0"


### PR DESCRIPTION
e.g. future search API etc.  So search will be 1.0 and may not be updated at the same time as Image or Presentation, may have a compliance doc, and a protocol, etc etc.
