### PR TITLE
Review and tweak wording of Presentation API change-log

### DIFF
--- a/source/api/presentation/2.0/change-log.md
+++ b/source/api/presentation/2.0/change-log.md
@@ -10,7 +10,7 @@ minor: 0
 pre: draft
 ---
 
-This document is a companion to the [IIIF Presentation API Specification, Version 2.0][prezi-api]. It describes the significant changes to the API since [Version 1.0][prezi-api-10]. The changes are broken into two groups: [Breaking Changes][breaking-changes], i.e. those that are not backwards compatible from either a client or server perspective (or both); [Other Changes][other-changes], i.e. those that are backwards compatible. A third section, [Deferred Proposals][deferred-proposals], lists proposals that been discussed but did not make it into this version of the specification.
+This document is a companion to the [IIIF Presentation API Specification, Version 2.0][prezi-api]. It describes the significant changes to the API since [Version 1.0][prezi-api-10]. The changes are broken into two groups: [Breaking Changes][breaking-changes], i.e. those that are not backwards compatible from either a client or server perspective (or both); [Other Changes][other-changes], i.e. those that are backwards compatible. A third section, [Deferred Proposals][deferred-proposals], lists proposals that have been discussed but did not make it into this version of the specification.
 
 In addition to changes in the API, the specification documents have been changed as follows:
 


### PR DESCRIPTION
Change log looks good. One bit of high-level wording I changed was to say "Deferred Proposals" instead of "Deferred Changes" since it struck me as really odd to have a list of changes... that weren't. A few tweaks and a number of back-ticks added.
