### PR TITLE
No keepalive in .htaccess in 2.2. closes #241

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -20,7 +20,7 @@ RewriteRule ^/?api/presentation/1.0/ /api/metadata/1.0/ [L,R=302]
 </FilesMatch>
 
 # http://httpd.apache.org/docs/current/mod/core.html#keepalive
-KeepAlive On
+# KeepAlive On
 
 # http://httpd.apache.org/docs/current/mod/mod_expires.html
 <IfModule mod_expires.c>


### PR DESCRIPTION
Commented out the line.
