### PR TITLE
Add back link to rotation note in Image API 1.1, remove python highlighting in 2.0

### DIFF
--- a/source/api/image/1.1/index.html
+++ b/source/api/image/1.1/index.html
@@ -1122,7 +1122,7 @@ layout: sub-page
               <li>
                 As described in <a href="#parameters-rotation">Section 4.2 (Rotation)</a>, in order to retain the size of the
                 requested image contents, rotation will change the width and height dimensions of the returned image file. A
-                formula for calculating the dimensions of the returned image file for a given rotation can be found here.
+                formula for calculating the dimensions of the returned image file for a given rotation can be found <a href="../../annex/notes/rotation.html">here</a>.
               </li>
             </ul>
           </section>


### PR DESCRIPTION
Both issues are part of #251.
1. Based on @azaroth42 input will leave 1.1 as is but should fix link
2. The python highlighting with `{% highlight python %}` renders the code snippets all red. Seems best to go back to non-specific code block
