### PR TITLE
Reversed alert notes

### DIFF
--- a/source/api/auth/0.9/index.md
+++ b/source/api/auth/0.9/index.md
@@ -17,7 +17,7 @@ cssversion: 2
 __This Version:__ {{ page.major }}.{{ page.minor }}.{{ page.patch }}{% if page.pre != 'final' %}-{{ page.pre }}{% endif %}
 
 __Beta Specification for Trial Use__
-This is a work in progress. We are actively seeking new implementations, updates to existing implementations, and feedback. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future.  Please send any feedback to [iiif-discuss@googlegroups.com][iiif-discuss].
+This is a work in progress. We are actively seeking implementations and feedback.  No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future.  Please send any feedback to [iiif-discuss@googlegroups.com][iiif-discuss].
 {: .alert}
 
 **Editors:**

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -20,7 +20,7 @@ __Latest Stable Version:__ [{{ site.image_api.latest.major }}.{{ site.image_api.
 __Previous Version:__ [2.0][prev-version]
 
 __Beta Specification for Trial Use__
-This is a work in progress. We are actively seeking implementations and feedback.  No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future.  Please send any feedback to [iiif-discuss@googlegroups.com][iiif-discuss].
+This is a work in progress. We are actively seeking new implementations, updates to existing implementations, and feedback. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future.  Please send any feedback to [iiif-discuss@googlegroups.com][iiif-discuss].
 {: .alert}
 
 **Editors:**


### PR DESCRIPTION
When I added the alert note to the Image API 2.1 I modified the wrong text (cut and pasted and then modified auth ...) :facepunch: 