### PR TITLE
Add maxWidth/maxHeight/maxArea, clarify compliance

### DIFF
--- a/source/api/image/2.1/compliance.md
+++ b/source/api/image/2.1/compliance.md
@@ -64,7 +64,7 @@ See also note under [Size][size] about combinations of Size and Region that may 
 |        | `sizeAboveFull`  | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
-Note that servers may express limits on the sizes available for an image with the optional `maxWidth`, `maxHeight` and/or `maxArea` [Profile Description properties][profile]. Servers are compliant provided they support the forms of the Size parameter shown above for image sizes up to the limits specified. Clients _SHOULD NOT_ assume that Region and Size parameter combinations such as `/full/full/` will be supported. 
+Note that servers may express limits on the sizes available for an image with the optional `maxWidth`, `maxHeight` and/or `maxArea` [Profile Description properties][profile]. Servers are compliant provided they support the forms of the Size parameter shown above for image sizes up to the limits specified. Clients should not assume that Region and Size parameter combinations such as `/full/full/` will be supported. 
 
 ### 3.3 Rotation
 

--- a/source/api/image/2.1/compliance.md
+++ b/source/api/image/2.1/compliance.md
@@ -14,12 +14,11 @@ pre: draft
 
 __This version:__ {{ page.major }}.{{ page.minor }}.{{ page.patch }}{% if page.pre != 'final' %}-{{ page.pre }}{% endif %}
 
-__Latest stable version:__ {{ site.image_api.latest.major }}.{{ site.image_api.latest.minor }}.{{ site.image_api.latest.patch }}
+__Latest stable version:__ [{{ site.image_api.latest.major }}.{{ site.image_api.latest.minor }}.{{ site.image_api.latest.patch }}][stable-version]
 
-## Introduction
-{:.no_toc}
-
-This document is a companion to the [IIIF Image API Specification][image-api]. It defines the set of supported parameters that correspond to different levels of compliance to the API.
+__Beta Specification for Trial Use__
+This is a work in progress. We are actively seeking new implementations, updates to existing implementations, and feedback. No section should be considered final, and the absence of any content does not imply that such content is out of scope, or may not appear in the future.  Please send any feedback to [iiif-discuss@googlegroups.com][iiif-discuss].
+{: .alert}
 
 ## Table of Contents
 {:.no_toc}
@@ -27,16 +26,19 @@ This document is a companion to the [IIIF Image API Specification][image-api]. I
 * Goes Here
 {:toc}
 
+## 1. Introduction
 
-## Compliance
+This document is a companion to the [IIIF Image API Specification][image-api]. It defines the set of supported parameters that correspond to different levels of compliance to the API.
 
-Three levels of compliance are defined. Level 0 is defined as the minimum set of supported parameters and features that _MUST_ be implemented to qualify the service as compliant to the IIIF standard. Level 1 is defined as the _RECOMMENDED_ set of parameters and features to be implemented.
+## 2. Compliance
+
+Three levels of compliance are defined. Level 0 is the minimum set of parameters and features that _MUST_ be implemented to qualify the service as compliant with the IIIF Image API Specification. Level 1 is the _RECOMMENDED_ set of parameters and features to be implemented. Note that servers may not support all combinations of all supported parameters and features, as noted in the appropriate sections below.
 
 In the tables below "![required][icon-req]" indicates that support is _REQUIRED_, and "![optional][icon-opt]" indicates that support is _OPTIONAL_.
 
-## Image Parameters
+## 3. Image Parameters
 
-### Region
+### 3.1 Region
 
 | Syntax      | Feature Name    | Level 0 | Level 1 | Level 2  |
 |:------------|:--------------- |:-------:|:-------:|:--------:|
@@ -46,21 +48,25 @@ In the tables below "![required][icon-req]" indicates that support is _REQUIRED_
 | `square`    | `regionSquare` | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
-### Size
+See also note under [Size][size] about combinations of Size and Region that may not be supported.
 
-| Syntax      | Feature Name        | Level 0 | Level 1 | Level 2  |
-|:------------|:--------------------|:-------:|:-------:|:--------:|
-| `full`      |                     | ![required][icon-req]      | ![required][icon-req]      | ![required][icon-req]       |
-| w,h         | `sizeByWhListed` | ![required][icon-req]      | ![required][icon-req]      | ![required][icon-req]       |
-| w,          | `sizeByW`         | ![optional][icon-opt]      | ![required][icon-req]      | ![required][icon-req]       |
-| ,h          | `sizeByH`         | ![optional][icon-opt]      | ![required][icon-req]      | ![required][icon-req]       |
-| pct:x       | `sizeByPct`       | ![optional][icon-opt]      | ![required][icon-req]      | ![required][icon-req]       |
-| w,h         | `sizeByForcedWh` | ![optional][icon-opt]      | ![optional][icon-opt]      | ![required][icon-req]       |
-| !w,h        | `sizeByWh`        | ![optional][icon-opt]      | ![optional][icon-opt]      | ![required][icon-req]       |
-|             | `sizeAboveFull`   | ![optional][icon-opt]      | ![optional][icon-opt]      | ![optional][icon-opt]       |
+### 3.2 Size
+
+| Syntax | Feature Name     | Level 0 | Level 1 | Level 2  |
+|:-------|:-----------------|:-------:|:-------:|:--------:|
+| `full` |                  | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
+| w,h    | `sizeByWhListed` | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
+| w,     | `sizeByW`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| ,h     | `sizeByH`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| pct:x  | `sizeByPct`      | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| w,h    | `sizeByForcedWh` | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+| !w,h   | `sizeByWh`       | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+|        | `sizeAboveFull`  | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
-### Rotation
+Note that servers may express limits on the sizes available for an image with the optional `maxWidth`, `maxHeight` and/or `maxArea` [Profile Description properties][profile]. Servers are compliant provided they support the forms of the Size parameter shown above for image sizes up to the limits specified. Clients _SHOULD NOT_ assume that Region and Size parameter combinations such as `/full/full/` will be supported. 
+
+### 3.3 Rotation
 
 | Syntax | Feature Name | Level 0 | Level 1 | Level 2  |
 |:-------|:-------------|:-------:|:-------:|:--------:|
@@ -70,7 +76,7 @@ In the tables below "![required][icon-req]" indicates that support is _REQUIRED_
 | !_n_ | `mirroring` | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
-### Quality
+### 3.4 Quality
 
 | Syntax        | Level 0 | Level 1 | Level 2  |
 |:--------------|:-------:|:-------:|:--------:|
@@ -80,7 +86,7 @@ In the tables below "![required][icon-req]" indicates that support is _REQUIRED_
 | `bitonal`     | ![optional][icon-opt]      | ![optional][icon-opt]      | ![required][icon-req]       |
 {: .api-table}
 
-### Format
+### 3.5 Format
 
 | Syntax      | Level 0 | Level 1 | Level 2  |
 |:------------|:-------:|:-------:|:--------:|
@@ -93,8 +99,7 @@ In the tables below "![required][icon-req]" indicates that support is _REQUIRED_
 | `webp`      | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
-
-## HTTP Features
+## 4. HTTP Features
 
 | HTTP Feature          | Feature Name          | Level 0 | Level 1 | Level 2  |
 |:----------------------|:----------------------|:-------:|:-------:|:--------:|
@@ -105,7 +110,7 @@ In the tables below "![required][icon-req]" indicates that support is _REQUIRED_
 | canonical link header | `canonicalLinkHeader` | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
-## Indicating Compliance
+## 5. Indicating Compliance
 
 Servers _MAY_ indicate compliance with by including a header in IIIF responses for images:
 
@@ -123,17 +128,25 @@ The URIs for the the compliance levels are as follows:
 | 2     | http://iiif.io/api/image/{{ page.major }}/level2.json |
 {: .urltemplate}
 
+### 5.1 Level 0 Compliance
+
 A level 0 compliant image server _MAY_ specify `scaleFactors` and/or `width` and `height` values for `tiles` in the Image Information response. At Level 0 compliance, a service is only required to deliver images of sizes computed using the scaling factors declared in the Image Information response. If specified they should be interpreted with the following special meanings:
 
  * `scaleFactors` - only the specified scaling factors are supported
  * `width`, `height` within `tiles` - clients should request only regions that correspond to output tiles of the specified dimensions
 
-If a client requests a size or region outside these parameters then the image server _MAY_ reject the request with an error.
+A level 0 compliant image server _MAY_ also specify `sizes` to indicate specific `width` and `height` values for sizes available for the `full` region.
 
-[image-api]: /api/image/2.0/ "Image API 2.0"
+If a client requests a combination of size and region outside these parameters then the image server _MAY_ reject the request with an error.
+
+[iiif-discuss]: mailto:iiif-discuss@googlegroups.com "Email Discussion List"
+[image-api]: /api/image/{{ page.major }}.{{ page.minor }}/ "Image API {{ page.major }}.{{ page.minor }}"
 [icon-req]: /img/metadata-api/required.png "Required"
 [icon-recc]: /img/metadata-api/recommended.png "Recommended"
 [icon-opt]: /img/metadata-api/optional.png "Optional"
 [icon-na]: /img/metadata-api/not_allowed.png "Not allowed"
+[size]: #size "3.2 Size"
+[profile]: /api/image/{{ page.major }}.{{ page.minor }}/#profile-description "5.3 Profile Description"
+[stable-version]: /api/image/{{ site.image_api.latest.major }}.{{ site.image_api.latest.minor }}/compliance.html "Stable Version"
 
 {% include acronyms.md %}

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -584,7 +584,7 @@ If any of `formats`, `qualities`, or `supports` have no additional values beyond
 
 URIs _MAY_ be added to the supports list of a profile to cover features not defined in this specification. Clients _MUST_ ignore URIs that are not recognized.
 
-The following fragment shows a profile indicating support for additional formats, qualities, and features beyond level 2 [compliance][compliance-levels].
+The following fragment shows a profile indicating support for additional formats, qualities, and features beyond level 2 [compliance][compliance-levels]. It also includes a size limit.
 
 {% highlight json %}
 {
@@ -597,6 +597,7 @@ The following fragment shows a profile indicating support for additional formats
     {
       "formats" : [ "gif", "pdf" ],
       "qualities" : [ "color", "gray" ],
+      "maxWidth" : 2000,
       "supports" : [
           "canonicalLinkHeader", "rotationArbitrary", "profileLinkHeader", "http://example.com/feature/"
       ]

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -545,9 +545,14 @@ In order to specify additional features that are supported for the image, a prof
 | `@id`       | Optional  | The URI of the profile. |
 | `@type`     | Optional  | The string "iiif:ImageProfile". |
 | `formats`   | Optional  | The set of image format parameter values available for the image.  If not specified then clients should assume only formats declared in the compliance level document.|
+| `maxArea`   | Optional  | The maximum area in pixels supported for this image. Requests for images sizes with width*height greater than this may not be supported. |
+| `maxHeight` | Optional  | The maximum height in pixels supported for this image. Requests for images sizes with height greater than this may not be supported. If `maxWidth` is specified and `maxHeight` is not, then clients should infer that `maxHeight = maxWidth`.  |
+| `maxWidth`  | Optional  | The maximum width in pixels supported for this image. Requests for images sizes with width greater than this may not be supported. _MUST_ be specified if `maxHeight` is specified. |
 | `qualities` | Optional  | The set of image quality parameter values available for the image.  If not specified then clients should assume only qualities declared in the compliance level document.|
 | `supports`  | Optional  | The set of features supported for the image.  If not specified then clients should assume only features declared in the compliance level document. |
 {: .api-table}
+
+The `maxWidth`, `maxHeight` and `maxArea` parameters provide a way for image servers to express limits on the sizes supported for the image. If `maxWidth` alone, or `maxWidth` and `maxHeight` are specified then clients should expect requests with larger linear dimensions to be rejected. If `maxArea` is specified then clients should expect requests with larger pixel areas to be rejected. The `maxWidth / maxHeight`  and `maxArea` parameters are independent, servers may implement either or both limits. Servers _MUST_ ensure that sizes specified within any `sizes` or `tiles` properties are with any size limits expressed. Clients _SHOULD NOT_ make requests that exceed size limits expressed.
 
 The set of features that may be specified in the `supports` property of an Image profile are:
 
@@ -752,7 +757,7 @@ The order in which servers parse requests and detect errors is not specified. A 
 | 400 Bad Request | This response is used when it is impossible for the server to fulfil the request, as the syntax of the request is incorrect.  For example, this would be used if the size parameter does not match any of the specified syntaxes. |
 | 401 Unauthorized | Authentication is required and not provided. See the [Authentication][authentication] section for details. |
 | 403 Forbidden | The user, authenticated or not, is not permitted to perform the requested operation. |
-| 404 Not Found | The image resource specified by [identifier] does not exist, or the value of one or more of the parameters is not supported for this image. |
+| 404 Not Found | The image resource specified by [identifier] does not exist, the value of one or more of the parameters is not supported for this image, or the requested size is greater than the limits specified. |
 | 500 Internal Server Error | The server encountered an unexpected error that prevented it from fulfilling the request. |
 | 501 Not Implemented | A valid IIIF request that is not implemented by this server. |
 | 503 Service Unavailable | Used when the server is busy/temporarily unavailable due to load/maintenance issues. An alternative to connection refusal with the option to specify a back-off period. |
@@ -867,8 +872,9 @@ Many thanks to  Ben Albritton, Matthieu Bonicel, Anatol Broder, Kevin Clarke, To
 [change-log11]: /api/image/1.1/change-log.html "Change Log for Version 1.1"
 [change-log20]: /api/image/2.0/change-log.html "Change Log for Version 2.0"
 [change-log21]: /api/image/2.1/change-log.html "Change Log for Version 2.1"
-[compliance]: /api/image/2.0/compliance.html "Image API Compliance"
-[compliance-quality]: /api/image/2.0/compliance.html#quality "Image API Compliance: Quality"
+[compliance]: /api/image/{{ page.major }}.{{ page.minor }}/compliance.html "Image API Compliance"
+[compliance-quality]: /api/image/{{ page.major }}.{{ page.minor }}/compliance.html#quality "Image API Compliance: Quality"
+
 [cors-spec]: http://www.w3.org/TR/cors/ "Cross-Origin Resource Sharing"
 [iiif-discuss]: mailto:iiif-discuss@googlegroups.com "Email Discussion List"
 [json-as-json-ld]: http://www.w3.org/TR/json-ld/#interpreting-json-as-json-ld "JSON-LD 1.0: 6.8 Interpreting JSON as JSON-LD"


### PR DESCRIPTION
Add maxWidth/maxHeight/maxArea, clarify compliance document regarding support for combinations of parameters, number compliance document sections following form of Image API, give Level 0 its own section. Fixes #620