### PR TITLE
Size and profile clarifications

### DIFF
--- a/source/api/image/2.1/compliance.md
+++ b/source/api/image/2.1/compliance.md
@@ -54,17 +54,18 @@ See also the note under [Size][size] about combinations of Size and Region that 
 
 ### 3.2 Size
 
-| Syntax | Feature Name     | Level 0 | Level 1 | Level 2  |
-|:-------|:-----------------|:-------:|:-------:|:--------:|
-| `full` |                  | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
-| `max`  |                  | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
-| w,h    | `sizeByWhListed` | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
-| w,     | `sizeByW`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
-| ,h     | `sizeByH`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
-| pct:n  | `sizeByPct`      | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
-| !w,h   | `sizeByForcedWh` | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
-| w,h    | `sizeByWh`       | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
-|        | `sizeAboveFull`  | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
+| Syntax | Feature Name        | Level 0 | Level 1 | Level 2  |
+|:-------|:--------------------|:-------:|:-------:|:--------:|
+| `full` |                     | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
+| `max`  |                     | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
+| w,h    | `sizeByWhListed`    | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
+| w,     | `sizeByW`           | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| ,h     | `sizeByH`           | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| pct:n  | `sizeByPct`         | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| !w,h   | `sizeByConfinedWh`  | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+| w,h    | `sizeByDistortedWh` | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+| w,h    | `sizeByWh`          | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+|        | `sizeAboveFull`     | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 
 Note that servers may express limits on the sizes available for an image with the optional `maxWidth`, `maxHeight` and/or `maxArea` [Profile Description properties][profile]. Servers are compliant provided they support the forms of the Size parameter shown above for image sizes up to the limits specified. Clients should not assume that Region and Size parameter combinations such as `/full/full/` will be supported.

--- a/source/api/image/2.1/compliance.md
+++ b/source/api/image/2.1/compliance.md
@@ -61,7 +61,7 @@ See also the note under [Size][size] about combinations of Size and Region that 
 | w,h    | `sizeByWhListed` | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
 | w,     | `sizeByW`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
 | ,h     | `sizeByH`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
-| pct:x  | `sizeByPct`      | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
+| pct:n  | `sizeByPct`      | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
 | !w,h   | `sizeByForcedWh` | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
 | w,h    | `sizeByWh`       | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
 |        | `sizeAboveFull`  | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |

--- a/source/api/image/2.1/compliance.md
+++ b/source/api/image/2.1/compliance.md
@@ -58,7 +58,6 @@ See also the note under [Size][size] about combinations of Size and Region that 
 |:-------|:--------------------|:-------:|:-------:|:--------:|
 | `full` |                     | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
 | `max`  |                     | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
-| w,h    | `sizeByWhListed`    | ![required][icon-req] | ![required][icon-req] | ![required][icon-req] |
 | w,     | `sizeByW`           | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
 | ,h     | `sizeByH`           | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
 | pct:n  | `sizeByPct`         | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
@@ -67,6 +66,8 @@ See also the note under [Size][size] about combinations of Size and Region that 
 | w,h    | `sizeByWh`          | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
 |        | `sizeAboveFull`     | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
+
+At any level of compliance, an image service whose Image Information response includes the `sizes` property must support requests for the sizes listed, and a service whose Image Information response includes the `tiles` property must support requests for the sizes implicit in the `width`, `height` and `scaleFactors` values given for tiles.
 
 Note that servers may express limits on the sizes available for an image with the optional `maxWidth`, `maxHeight` and/or `maxArea` [Profile Description properties][profile]. Servers are compliant provided they support the forms of the Size parameter shown above for image sizes up to the limits specified. Clients should not assume that Region and Size parameter combinations such as `/full/full/` will be supported.
 
@@ -132,7 +133,7 @@ The URIs for the the compliance levels are as follows:
 | 0     | http://iiif.io/api/image/{{ page.major }}/level0.json |
 | 1     | http://iiif.io/api/image/{{ page.major }}/level1.json |
 | 2     | http://iiif.io/api/image/{{ page.major }}/level2.json |
-{: .urltemplate}
+{: .urltemplate .api-table}
 
 ### 5.1 Level 0 Compliance
 

--- a/source/api/image/2.1/compliance.md
+++ b/source/api/image/2.1/compliance.md
@@ -62,8 +62,8 @@ See also the note under [Size][size] about combinations of Size and Region that 
 | w,     | `sizeByW`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
 | ,h     | `sizeByH`        | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
 | pct:x  | `sizeByPct`      | ![optional][icon-opt] | ![required][icon-req] | ![required][icon-req] |
-| w,h    | `sizeByForcedWh` | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
-| !w,h   | `sizeByWh`       | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+| !w,h   | `sizeByForcedWh` | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
+| w,h    | `sizeByWh`       | ![optional][icon-opt] | ![optional][icon-opt] | ![required][icon-req] |
 |        | `sizeAboveFull`  | ![optional][icon-opt] | ![optional][icon-opt] | ![optional][icon-opt] |
 {: .api-table}
 

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -596,7 +596,6 @@ The set of features that may be specified in the `supports` property of an Image
 | `sizeByWh` | Size of images may be requested in the form "w,h" where the supplied w and h preserve the aspect ratio.  |
 | `sizeByWhListed` | _Deprecated as an explicit named feature in 2.1 and will be removed in 3.0._ |
 | `sizeByForcedWh` | _Deprecated in favour of 'sizeByDistortedWh' in 2.1 and will be removed in 3.0._  |
-
 {: .api-table #features}
 
 The features `sizeByWh` and `sizeByDistortedWh` share the same "w,h" syntax for the size parameter, but they represent separate features. A server that supports `sizeByWh` but not `sizeByDistortedWh` would serve an image response at any scale (subject to separate `maxWidth`, `maxHeight`, `maxArea` and `sizeAboveFull` constraints if present), but only if the resulting image preserved the original aspect ratio. Requests for distorted images would not be served.

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -218,7 +218,7 @@ If the resulting height or width is zero, then the server _SHOULD_ return a 400 
 The image server _MAY_ support scaling above the full size of the extracted region.
 
 __Deprecation Warning__
-The size keyword `full` will be replaced in favor of `max` in Version 3.0. Feedback is welcome via [iiif-discuss][iiif-discuss] or on the [Github issue](https://github.com/IIIF/iiif.io/issues/678).
+The size keyword `full` will be replaced in favor of `max` in version 3.0. Feedback is welcome via [iiif-discuss][iiif-discuss] or on the [Github issue](https://github.com/IIIF/iiif.io/issues/678).
 {: .warning #full-dep}
 
 Examples:
@@ -594,12 +594,12 @@ The set of features that may be specified in the `supports` property of an Image
 | `sizeByPct` | Size of images may be requested in the form "pct:n".  |
 | `sizeByW` | Size of images may be requested in the form "w,".  |
 | `sizeByWh` | Size of images may be requested in the form "w,h" where the supplied w and h preserve the aspect ratio.  |
-| `sizeByWhListed` | See [deprecation warning below][dep-sizes] |
-| `sizeByForcedWh` | See [deprecation warning below][dep-sizes]  |
+| `sizeByWhListed` | See [deprecation warning below][dep-sizes]. |
+| `sizeByForcedWh` | See [deprecation warning below][dep-sizes]. |
 {: .api-table #features}
 
 __Deprecation Warning__
-Use of the named features `sizeByWhListed` and `sizeByForcedWh` is deprecated in version 2.1 of the specification, and they will be removed in version 3.0. 
+Use of the feature names `sizeByWhListed` and `sizeByForcedWh` is deprecated in version 2.1 of the specification. These names will be removed in version 3.0. `sizeByForcedWh` was inconsistently defined in version 2.0, and `sizeByWhListed` is implied by listing the sizes in the image information document and is therefore not required as a named feature.
 {: .warning #dep-sizes}
 
 The features `sizeByWh` and `sizeByDistortedWh` share the same "w,h" syntax for the size parameter, but they represent separate features. A server that supports `sizeByWh` but not `sizeByDistortedWh` would serve an image response at any scale (subject to separate `maxWidth`, `maxHeight`, `maxArea` and `sizeAboveFull` constraints if present), but only if the resulting image preserved the original aspect ratio. Requests for distorted images would not be served.

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -588,13 +588,20 @@ The set of features that may be specified in the `supports` property of an Image
 | `rotationArbitrary` |   Rotation of images may be requested by degrees other than multiples of 90. |
 | `rotationBy90s` |   Rotation of images may be requested by degrees in multiples of 90. |
 | `sizeAboveFull` | Size of images may be requested larger than the "full" size. See [warning][max-dos-warning]. |
-| `sizeByWhListed` | Size of images given in the `sizes` field of the Image Information document may be requested using the `w,h` syntax. |
-| `sizeByForcedWh` | Size of images may be requested in the form "!w,h".  |
+| `sizeByConfinedWh` | Size of images may be requested in the form "!w,h". |
+| `sizeByDistortedWh` | Size of images may be requested in the form "w,h", including sizes that would distort the image   |
 | `sizeByH` | Size of images may be requested in the form ",h".  |
 | `sizeByPct` | Size of images may be requested in the form "pct:n".  |
 | `sizeByW` | Size of images may be requested in the form "w,".  |
-| `sizeByWh` | Size of images may be requested in the form "w,h".  |
+| `sizeByWh` | Size of images may be requested in the form "w,h" where the supplied w and h preserve the aspect ratio  |
+| `sizeByWhListed` | Size of images listed in the `sizes` property of the Image Information document may be requested using the `w,h` syntax. |
+| `sizeByForcedWh` | _Deprecated in 2.1 and will be removed in 3.0_  |
+
 {: .api-table #features}
+
+The features `sizeByWh` and `sizeByDistortedWh` share the same "w,h" syntax for the size parameter, but they represent separate features. A server that supports `sizeByWh` but not `sizeByDistortedWh` would serve an image response at any scale (subject to separate `maxWidth`, `maxHeight`, `maxArea` and `sizeAboveFull` constraints if present), but only if the resulting image preserved the original aspect ratio. Requests for distorted images would not be served.
+
+A server that supports `sizeByWhListed` but not `sizeByW` or `sizeByWh` is only required to serve the images explicitly listed under the `sizes` property of the Image Information Document, allowing for a static file implementation.
 
 The set of features, formats and qualities supported is the union of those declared in all of the external profile documents and any embedded profile objects.  If a feature is not present in either the profile document or the `supports` property of an embedded profile, then a client _MUST_ assume that the feature is not supported.
 

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -594,9 +594,13 @@ The set of features that may be specified in the `supports` property of an Image
 | `sizeByPct` | Size of images may be requested in the form "pct:n".  |
 | `sizeByW` | Size of images may be requested in the form "w,".  |
 | `sizeByWh` | Size of images may be requested in the form "w,h" where the supplied w and h preserve the aspect ratio.  |
-| `sizeByWhListed` | _Deprecated as an explicit named feature in 2.1 and will be removed in 3.0._ |
-| `sizeByForcedWh` | _Deprecated in favour of 'sizeByDistortedWh' in 2.1 and will be removed in 3.0._  |
+| `sizeByWhListed` | See [deprecation warning below][dep-sizes] |
+| `sizeByForcedWh` | See [deprecation warning below][dep-sizes]  |
 {: .api-table #features}
+
+__Deprecation Warning__
+Use of the named features `sizeByWhListed` and `sizeByForcedWh` is deprecated in version 2.1 of the specification, and they will be removed in version 3.0. 
+{: .warning #dep-sizes}
 
 The features `sizeByWh` and `sizeByDistortedWh` share the same "w,h" syntax for the size parameter, but they represent separate features. A server that supports `sizeByWh` but not `sizeByDistortedWh` would serve an image response at any scale (subject to separate `maxWidth`, `maxHeight`, `maxArea` and `sizeAboveFull` constraints if present), but only if the resulting image preserved the original aspect ratio. Requests for distorted images would not be served.
 
@@ -961,6 +965,7 @@ Many thanks to  Ben Albritton, Matthieu Bonicel, Anatol Broder, Kevin Clarke, To
 [prev-version]: http://iiif.io/api/image/1.1/ "Previous Version"
 [stable-version]: http://iiif.io/api/image/{{ site.image_api.latest.major }}.{{ site.image_api.latest.minor }}/ "Stable Version"
 [wsgi]: https://www.python.org/dev/peps/pep-0333/
+[dep-sizes]: #dep-sizes "Deprecated sizes warning"
 
 [client-auth-img]: img/auth-flow-client.png
 [server-auth-img]: img/auth-flow-server.png

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -599,7 +599,7 @@ The set of features that may be specified in the `supports` property of an Image
 {: .api-table #features}
 
 __Deprecation Warning__
-Use of the feature names `sizeByWhListed` and `sizeByForcedWh` is deprecated in version 2.1 of the specification. These names will be removed in version 3.0. `sizeByForcedWh` was inconsistently defined in version 2.0, and `sizeByWhListed` is implied by listing the sizes in the image information document and is therefore not required as a named feature.
+Use of the feature names `sizeByWhListed` and `sizeByForcedWh` is deprecated. These names will be removed in version 3.0. `sizeByForcedWh` was inconsistently defined in version 2.0, and `sizeByWhListed` is implied by listing the sizes in the image information document and is therefore not required as a named feature.
 {: .warning #dep-sizes}
 
 The features `sizeByWh` and `sizeByDistortedWh` share the same "w,h" syntax for the size parameter, but they represent separate features. A server that supports `sizeByWh` but not `sizeByDistortedWh` would serve an image response at any scale (subject to separate `maxWidth`, `maxHeight`, `maxArea` and `sizeAboveFull` constraints if present), but only if the resulting image preserved the original aspect ratio. Requests for distorted images would not be served.

--- a/source/api/image/2.1/index.md
+++ b/source/api/image/2.1/index.md
@@ -589,19 +589,19 @@ The set of features that may be specified in the `supports` property of an Image
 | `rotationBy90s` |   Rotation of images may be requested by degrees in multiples of 90. |
 | `sizeAboveFull` | Size of images may be requested larger than the "full" size. See [warning][max-dos-warning]. |
 | `sizeByConfinedWh` | Size of images may be requested in the form "!w,h". |
-| `sizeByDistortedWh` | Size of images may be requested in the form "w,h", including sizes that would distort the image   |
+| `sizeByDistortedWh` | Size of images may be requested in the form "w,h", including sizes that would distort the image.   |
 | `sizeByH` | Size of images may be requested in the form ",h".  |
 | `sizeByPct` | Size of images may be requested in the form "pct:n".  |
 | `sizeByW` | Size of images may be requested in the form "w,".  |
-| `sizeByWh` | Size of images may be requested in the form "w,h" where the supplied w and h preserve the aspect ratio  |
-| `sizeByWhListed` | Size of images listed in the `sizes` property of the Image Information document may be requested using the `w,h` syntax. |
-| `sizeByForcedWh` | _Deprecated in 2.1 and will be removed in 3.0_  |
+| `sizeByWh` | Size of images may be requested in the form "w,h" where the supplied w and h preserve the aspect ratio.  |
+| `sizeByWhListed` | _Deprecated as an explicit named feature in 2.1 and will be removed in 3.0._ |
+| `sizeByForcedWh` | _Deprecated in favour of 'sizeByDistortedWh' in 2.1 and will be removed in 3.0._  |
 
 {: .api-table #features}
 
 The features `sizeByWh` and `sizeByDistortedWh` share the same "w,h" syntax for the size parameter, but they represent separate features. A server that supports `sizeByWh` but not `sizeByDistortedWh` would serve an image response at any scale (subject to separate `maxWidth`, `maxHeight`, `maxArea` and `sizeAboveFull` constraints if present), but only if the resulting image preserved the original aspect ratio. Requests for distorted images would not be served.
 
-A server that supports `sizeByWhListed` but not `sizeByW` or `sizeByWh` is only required to serve the images explicitly listed under the `sizes` property of the Image Information Document, allowing for a static file implementation.
+A server that supports neither `sizeByW` or `sizeByWh` is only required to serve the image sizes listed under the `sizes` property or implied by the `tiles` property of the Image Information Document, allowing for a static file implementation.
 
 The set of features, formats and qualities supported is the union of those declared in all of the external profile documents and any embedded profile objects.  If a feature is not present in either the profile document or the `supports` property of an embedded profile, then a client _MUST_ assume that the feature is not supported.
 

--- a/source/api/image/2/level0.json
+++ b/source/api/image/2/level0.json
@@ -5,5 +5,5 @@
 
   "formats": ["jpg"],
   "qualities": ["default"],
-  "supports": []
+  "supports": ["sizeByWhListed"]
 }

--- a/source/api/image/2/level1.json
+++ b/source/api/image/2/level1.json
@@ -6,6 +6,7 @@
   "formats": ["jpg"],
   "qualities": ["default"],
   "supports": [
+    "sizeByWhListed",
     "baseUriRedirect",
     "cors",
     "jsonldMediaType",

--- a/source/api/image/2/level2.json
+++ b/source/api/image/2/level2.json
@@ -6,6 +6,7 @@
   "formats": ["jpg", "png"],
   "qualities": ["default", "bitonal"],
   "supports": [
+    "sizeByWhListed",
     "baseUriRedirect",
     "cors",
     "jsonldMediaType",

--- a/source/api/image/2/level2.json
+++ b/source/api/image/2/level2.json
@@ -6,18 +6,19 @@
   "formats": ["jpg", "png"],
   "qualities": ["default", "bitonal"],
   "supports": [
-    "sizeByWhListed",
     "baseUriRedirect",
     "cors",
     "jsonldMediaType",
     "profileLinkHeader",
+    "regionByPct",
     "regionByPx",
+    "rotationBy90s",
+    "sizeByConfinedWh",
+    "sizeByDistortedWh",
+    "sizeByForcedWh",
     "sizeByH",
     "sizeByPct",
     "sizeByW",
-    "regionByPct",
-    "rotationBy90s",
-    "sizeByForcedWh",
     "sizeByWh"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/IIIF/iiif.io/issues/720
Question - those profiles are for 2.0 too (because semver) - is that a problem? 

Fixes sizeByForcedWh syntax typo in compliance doc
Question - should this be fixed in the 2.0 compliance doc too?