### PR TITLE
Rename auth and prezi API docs

### DIFF
--- a/source/api/auth/0.9/index.md
+++ b/source/api/auth/0.9/index.md
@@ -461,8 +461,8 @@ Many thanks to the members of the [IIIF Community][iiif-community] for their con
 
 | Date       | Description |
 | ---------- | ----------- |
-| 2015-10-30 | Version 0.9.1 (Alchemical Key); add missing @context, clarifications |
-| 2015-07-28 | Version 0.9.0 (Alchemical Key); beta specification for review |
+| 2015-10-30 | Version 0.9.1 (Table Flip) add missing @context, clarifications |
+| 2015-07-28 | Version 0.9.0 (unnamed) draft |
 {: .api-table}
 
 [jsonp]: http://en.wikipedia.org/wiki/JSONP "JSONP"

--- a/source/api/presentation/2.1/index.md
+++ b/source/api/presentation/2.1/index.md
@@ -1822,7 +1822,7 @@ Many thanks to Matthieu Bonicel, Tom Cramer, Ian Davis, Markus Enders, Renhart G
 
 | Date       | Description                                        |
 | ---------- | -------------------------------------------------- |
-| 2016-02-26 | Version 2.1.0-draft5 (Trip Life) [View change log][change-log] |
+| 2016-02-26 | Version 2.1.0-draft5 (Hinty McHintface) [View change log][change-log] |
 | 2014-09-11 | Version 2.0 (Triumphant Giraffe) [View change log][change-log-20] |
 | 2013-08-26 | Version 1.0 (unnamed) released                     |
 | 2013-06-14 | Version 0.9 (unnamed) released                     |


### PR DESCRIPTION
Closes #756 by addressing current drafts of prezi 2.1 and auth 0.9.x