### PR TITLE
Fix __ to _ typo for RFC MUST

### DIFF
--- a/source/api/presentation/2.1/index.md
+++ b/source/api/presentation/2.1/index.md
@@ -302,7 +302,7 @@ A link to an external resource intended to be displayed directly to the user, an
  * Any resource type _MAY_ have one or more external resources related to it.
 
 ##### rendering
-A link to an external resource intended for display or download by a human user. This property can be used to link from a manifest, collection or other resource to the preferred viewing environment for that resource, such as a viewer page on the publisher's web site. Other uses include a rendering of a manifest as a PDF or EPUB with the images and text of the book, or a slide deck with images of the museum object. A label and the format of the rendering resource __MUST__ be supplied to allow clients to present the option to the user.
+A link to an external resource intended for display or download by a human user. This property can be used to link from a manifest, collection or other resource to the preferred viewing environment for that resource, such as a viewer page on the publisher's web site. Other uses include a rendering of a manifest as a PDF or EPUB with the images and text of the book, or a slide deck with images of the museum object. A label and the format of the rendering resource _MUST_ be supplied to allow clients to present the option to the user.
 
  * Any resource type _MAY_ have one or more external rendering resources.
 


### PR DESCRIPTION
Non normative fix to Presentation API rendering property description from __ to _ of an RFC MUST.
Fixes #782.

(Not deploying temporary site for a two character fix)