### PR TITLE
remove double lines

### DIFF
--- a/source/api/image/2.0/compliance.md
+++ b/source/api/image/2.0/compliance.md
@@ -110,10 +110,10 @@ In the tables below "![required][icon-req]" indicates that support is _REQUIRED_
 
 Servers _MAY_ indicate compliance with by including a header in IIIF responses for images:
 
-```
+``` none
 Link: <http://iiif.io/api/image/{{ page.major }}/level1.json>;rel="profile"
 ```
-{: .urltemplate}
+
 
 The URIs for the the compliance levels are as follows:
 
@@ -122,7 +122,7 @@ The URIs for the the compliance levels are as follows:
 | 0     | http://iiif.io/api/image/{{ page.major }}/level0.json |
 | 1     | http://iiif.io/api/image/{{ page.major }}/level1.json |
 | 2     | http://iiif.io/api/image/{{ page.major }}/level2.json |
-{: .urltemplate}
+{: .api-table}
 
 A level 0 compliant image server _MAY_ specify `scaleFactors` and/or `width` and `height` values for `tiles` in the Image Information response. At Level 0 compliance, a service is only required to deliver images of sizes computed using the scaling factors declared in the Image Information response. If specified they should be interpreted with the following special meanings:
 

--- a/source/api/image/2.0/index.md
+++ b/source/api/image/2.0/index.md
@@ -700,7 +700,6 @@ Early sanity checking of URIs (lengths, trailing GET, invalid characters, out-of
     if (yr + th*s > height):
         hs = (height - yr + s - 1) / s
 ```
-{: .urltemplate}
 
   * As described in [Rotation][rotation], in order to retain the size of the requested image contents, rotation will change the width and height dimensions of the image returned. A formula for calculating the dimensions of the image returned for a given starting size and rotation is given below. Note that the rounding method is implementation dependent and that some languages require conversion of the angle from degrees to radians.
 
@@ -709,7 +708,6 @@ Early sanity checking of URIs (lengths, trailing GET, invalid characters, out-of
     w_returned = abs(w*cos(n)) + abs(h*sin(n))
     h_returned = abs(h*cos(n)) + abs(w*sin(n))
 ```
-{: .urltemplate}
 
 ### B. Versioning
 


### PR DESCRIPTION
from Image API 2.0. Checked the other specs and couldn't find any more.