### PR TITLE
Clarify SpecRes, Choice for image annos

### DIFF
--- a/source/api/presentation/2.1/index.md
+++ b/source/api/presentation/2.1/index.md
@@ -699,9 +699,9 @@ If a [IIIF Image API][image-api] service is available for the image, then a link
 
 Although it seems redundant, the URI of the canvas _MUST_ be repeated in the `on` field of the Annotation. This is to ensure consistency with annotations that target only part of the resource, described in more detail below.
 
-Additional features of the [Open Annotation][openanno] data model _MAY_ also be used, such as selecting a segment of the canvas or content resource, or embedding the comment or transcription within the annotation. These additional features are described in the following sections.
+Additional features of the [Open Annotation][openanno] data model _MAY_ also be used, such as selecting a segment of the canvas or content resource, or embedding the comment or transcription within the annotation. These additional features are described in the following section.  The use of advanced features sometimes results in situations where the resource is not an image, but instead a `SpecificResource`, a `Choice` or other non content object. Implementations should check the type of the resource and not assume that it is always an image. 
 
-The annotations that associate images, and only those annotations that associate images, are included in the canvas in the `images` property.  Other annotations, including both those that paint resources on the canvas and those that comment about the canvas, are included by referencing annotation lists, discussed in the following section.
+Only the annotations that associate images or parts of images are included in the canvas in the `images` property.  Other annotations, including both those that paint resources on the canvas and those that comment about the canvas, are included by referencing annotation lists, discussed in the following section.
 
 ``` json-doc
 {


### PR DESCRIPTION
http://specific_image.iiif.io/api/presentation/2.1/#image-resources

Add note that just because it SHOULD be an image, doesn't mean that it always will be one, and there are lots of valid situations to test for.

Closes #816