### PR TITLE
Added Google notification

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,4 +25,14 @@ namespace :deploy do
   end
 end
 
+namespace :notify do
+  desc 'Notify Google about sitemap update'
+  task :google do
+    run_locally do
+      res = Net::HTTP.get(URI("http://www.google.com/ping?sitemap=http://#{application}/sitemap.xml"))
+    end
+  end
+end
+
 after "deploy:symlink:release", "deploy:update_jekyll"
+after "deploy:published", "notify:google"


### PR DESCRIPTION
For #700. This should ping google after the build has completed. Not sure how to test the Capistrano workflow without being able to deploy. The http call has been tested and Google does pick it up. Namespacing under notify allows future notifications to be slotted in if there are other services to notify.