### PR TITLE
Link jp translations, fix minor typos

### DIFF
--- a/source/api/index.md
+++ b/source/api/index.md
@@ -29,10 +29,11 @@ We welcome feedback on all IIIF Specifications. In particular, we are actively s
 
 ## Community Translations
 
-| API              | Version | Translation          |
-| ---------------- | ------- | -------------------- |
-| Image API        | 2.1     | [Japanese][image-jp] |
-| Presentation API | 2.1     | [Japanese][prezi-jp] |
+| API              | Version | Translation           |
+| ---------------- | ------- | --------------------- |
+| Image API        | 2.1     | [Japanese][image-jp]  |
+| Presentation API | 2.1     | [Japanese][prezi-jp]  |
+| Search API       | 1.0     | [Japanese][search-jp] |
 {: .api-table}
 
 __Translation Note__<br/>
@@ -64,6 +65,7 @@ IIIF Specifications are created and published following the [IIIF Editorial Proc
 
 [image-jp]: http://www.asahi-net.or.jp/~ax2s-kmtn/ref/iiif/apiimage2.1.html
 [prezi-jp]: http://www.asahi-net.or.jp/~ax2s-kmtn/ref/iiif/apipresentation2.1.html
+[search-jp]: http://www.asahi-net.or.jp/~ax2s-kmtn/ref/iiif/searchapi1.0.html
 
 [iiif-discuss]: mailto:iiif-discuss@googlegroups.com "Email Discussion List"
 [image21]: /api/image/2.1/ "Image API v2.1"

--- a/source/api/index.md
+++ b/source/api/index.md
@@ -23,11 +23,23 @@ cssversion: 2
 {: .api-table}
 
 
-__Feedback Requested__
+__Feedback Requested__<br/>
 We welcome feedback on all IIIF Specifications. In particular, we are actively seeking implementations and feedback on the Authentication API draft specification. Please send any feedback to [iiif-discuss@googlegroups.com][iiif-discuss].
 {: .alert}
 
-## Old Versions
+## Community Translations
+
+| API              | Version | Translation          |
+| ---------------- | ------- | -------------------- |
+| Image API        | 2.1     | [Japanese][image-jp] |
+| Presentation API | 2.1     | [Japanese][prezi-jp] |
+{: .api-table}
+
+__Translation Note__<br/>
+Please note that the IIIF community does not guarantee the accuracy of any translation. They are linked to for information purposes only, and any discrepancies with the specifications are unintentional. The English versions of the specifications linked above are the definitive versions.
+{: .alert}
+
+## Older Versions
 
 Current IIIF specifications _SHOULD_ be used for all new work. Old versions are retained for reference and are listed below.
 
@@ -49,6 +61,9 @@ IIIF also has a series of [Implementation Notes][notes] which are not subject to
 ## Process
 
 IIIF Specifications are created and published following the [IIIF Editorial Process][editors].
+
+[image-jp]: http://www.asahi-net.or.jp/~ax2s-kmtn/ref/iiif/apiimage2.1.html
+[prezi-jp]: http://www.asahi-net.or.jp/~ax2s-kmtn/ref/iiif/apipresentation2.1.html
 
 [iiif-discuss]: mailto:iiif-discuss@googlegroups.com "Email Discussion List"
 [image21]: /api/image/2.1/ "Image API v2.1"

--- a/source/api/presentation/2.1/index.md
+++ b/source/api/presentation/2.1/index.md
@@ -743,9 +743,9 @@ Annotation Lists are separate resources that _SHOULD_ be dereferenced when encou
 
 The {name} parameter in the URI pattern _MUST_ uniquely distinguish it from all other lists, and is typically the same name as the canvas. As a single canvas may have multiple lists of additional resources, perhaps divided by type, this _MUST NOT_ be assumed however, and the URIs must be followed rather than constructed _a priori_.
 
-The annotation list _MUST_ have an http(s) URI given in `@id`, and the the JSON representation _MUST_ be returned when that URI is dereferenced.  They _MAY_ have any of the other fields defined in this specification.
+The annotation list _MUST_ have an http(s) URI given in `@id`, and the JSON representation _MUST_ be returned when that URI is dereferenced.  They _MAY_ have any of the other fields defined in this specification.
 
-The annotations, as described above, are given in a `resources` list. The resource linked by the annotation _MUST_ something other than an image if the motivation is `sc:painting`, these are recorded in the `images` property of the canvas. The canvas URI _MUST_ be repeated in the `on` field, as above.
+The annotations, as described above, are given in a `resources` list. The resource linked by the annotation _MUST_ be something other than an image if the motivation is `sc:painting`, these are recorded in the `images` property of the canvas. The canvas URI _MUST_ be repeated in the `on` field, as above.
 
 The format of the resource _SHOULD_ be included and _MUST_ be the media type that is returned when the resource is dereferenced. The type of the content resource _SHOULD_ be taken from this [list in the Open Annotation specification][openannotypes], or a similar well-known resource type ontology. For resources that are displayed as part of the rendering (such as images, text transcriptions, performances of music from the manuscript and so forth) the motivation _MUST_ be "sc:painting". The content resources _MAY_ also have any of the other fields defined in this specification, including commonly `label`, `description`, `metadata`, `license` and `attribution`.
 

--- a/source/api/search/1.0/index.md
+++ b/source/api/search/1.0/index.md
@@ -178,7 +178,7 @@ Clients wishing to know the total number of annotations that match may count the
 
 #### 3.3.2. Paging Results
 
-For long lists of annnotations, the server may choose to divide the response into multiple sections, often called pages.  Each page is an annotation list and can refer to other pages to allow the client to traverse the entire set.  This uses the [paging features][paging] introduced in version 2.1 of the Presentation API, but is backwards compatible with version 2.0.  The next page of results that follows the current response _MUST_ be referenced in a `next` property of the annotation list, and the previous page _SHOULD_ be referenced in a `prev` property.  
+For long lists of annotations, the server may choose to divide the response into multiple sections, often called pages.  Each page is an annotation list and can refer to other pages to allow the client to traverse the entire set.  This uses the [paging features][paging] introduced in version 2.1 of the Presentation API, but is backwards compatible with version 2.0.  The next page of results that follows the current response _MUST_ be referenced in a `next` property of the annotation list, and the previous page _SHOULD_ be referenced in a `prev` property.  
 
 The URI of the first annotation list reported in the `@id` property _MAY_ be different from the one used by the client to request the search.  Each page _SHOULD_ also have a `startIndex` property with an integer value that reports the position of the first result within the entire result set, where the first annotation has an index of 0.  For example, if the client has requested the first page which has 10 hits, then the `startIndex` will be 0, and the `startIndex` of second page will be 10, being the 11th hit.
 


### PR DESCRIPTION

See: http://jp_typos.iiif.io/api/
