### PR TITLE
added link to events on community page

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -40,6 +40,11 @@ redirect_from:
                 <pre style="padding-left: 30px"><a href="http://bit.ly/iiif-slack">http://bit.ly/iiif-slack</a></pre>
             </div>
 
+            <div>
+              Attend a IIIF Event:
+                <pre style="padding-left: 30px"><a href="http://iiif.io/event/">http://iiif.io/event/</a></pre>
+            </div>
+
             <div>There are also bi-weekly teleconferences, the details of which are posted in the iiif-discuss list. All community members are welcome and encouraged to participate in the calls.  Notes from the calls are posted in <a href="https://drive.google.com/drive/u/0/folders/0B8APFBow4sHvUHBtVmh3VE01OW8">this Google Drive folder</a>.</div>
           </section>
 


### PR DESCRIPTION
See http://link_to_events.iiif.io/community/ so people can actually get to the Events page