### PR TITLE
Fix lineheight for RFC highlighted text

### DIFF
--- a/source/css/spec-doc.scss
+++ b/source/css/spec-doc.scss
@@ -276,7 +276,8 @@ pre {
   color: #d55;
   font-variant: small-caps;
   font-style: normal;
-  font-size: 1.2em
+  font-size: 1.2em;
+  line-height: 0.8333
 }
 .legend {
   width: 50%

--- a/source/css/spec-doc2.scss
+++ b/source/css/spec-doc2.scss
@@ -275,7 +275,8 @@ pre {
   color: #d55;
   font-variant: small-caps;
   font-style: normal;
-  font-size: 1.2em
+  font-size: 1.2em;
+  line-height: 0.8333
 }
 .legend {
   width: 50%


### PR DESCRIPTION
Fixes #606. Have checked on current Chrome/Firefox/Safari on Mac.