### PR TITLE
added full schedule with timetables

### DIFF
--- a/source/event/2016/thehague.md
+++ b/source/event/2016/thehague.md
@@ -26,7 +26,74 @@ The International Image Interoperability Framework ([IIIF][home-page]) Working G
 
 ### Schedule
 
-The session schedule is available through [sched][sched].  
+The session schedule is available through [sched][sched].
+
+#### Wednesday, October 19, Morning  
+
+| Time          | Session            | Presenters                        |
+|---------------|--------------------|-----------------------------------|
+| 8:30 - 9:00   | _Coffee_              | |
+| 9:00 - 9:15   | Welcome and Community Status Update      | Antoine Isaac (Europeana), Tom Cramer (Stanford), and Sheila Rabun (IIIF)             |
+| 9:15 - 9:35   | Specification Status Update  | IIIF Editors |
+| 9:35 - 10:10  | Lightning Talks       | |
+|               | Stitching Together an Institution with IIIF: The rewards and challenges of using IIIF as an integrating technology at Harvard   | Judson Harward (Harvard University) |
+|               | Indigenous Digital Archive             | Tom Crane (Digirati) |
+|               | Five Mirador Use Cases for Museums          | Alan Newman (National Gallery of Art) |
+|               | The Digital Manuscripts Toolkit | Emma Stanford (University of Oxford Bodleian Libraries)        |
+|               | Fun with IIIF APIs | Tristan Roddis (Cogapp)            |
+| 10:10 - 10:25 | _Break_               | |
+| 10:25 - 11:30 | Lightning Talks       | |
+|               | Creating annotations with the SimpleAnnotationServer and supporting Search API | Glen Robson (National Library of Wales)
+|               | Composable Software Components  | Drew Winget (Stanford) |
+|               | Using Mirador for research in humanities at Yale University          | Seong-June Kim (Yale) |
+|               | Ed Ruscha Streets of LA Archive                | Chris Edwards (The Getty Research Institute) |
+|               | Making IIIF resources discoverable in Europeana              | Nuno Freire (Europeana) |
+|               | Image Similarity Search at the BSB              | Johannes Baiter (Bavarian State Library) |
+|               | Image Similarity Search: Technical Aspects              | Thomas Meiers (Bavarian State Library) |
+|               | Artstor and IIIF              | William Ying (Artstor) |
+|               | Perceptual Hashing on Media Files              | Maarten Zeinstra (Kennisland) |
+|               | Update on UGhent IIIF golive              | Dries Moreels (Ghent University Library) |
+| 11:30 - 12:00 | Introduction to Forthcoming sessions      | Session leaders             |
+| 12:00 - 1:30  | _Lunch on your own_  | |
+{: .api-table .sched-table}
+
+#### Wednesday, October 19, Afternoon
+
+| Time          | Room A       | Room B/C     | Room D     |
+|---------------|---------------|-------------|-------------|
+| 1:30 - 3:30  | Software Developers Interest Group | Discovery | -- |
+| 3:30 - 3:45  | _Break_ | _Break_ | _Break_ |
+| 3:45 - 5:00 | Community Norms | Notifications | -- |
+{: .api-table .msched-table}
+
+#### Thursday, October 20
+
+| Time          | Room A       | Room B/C     | Room D     |
+|---------------|---------------|-------------|-------------|
+| 8:30 - 9:00   | _Coffee_ | _Coffee_ | _Coffee_ |
+| 9:00 - 10:30  | API Issue Review| Mirador Community and Technology | IIIF Documentation |
+| 10:30 - 10:45 | _Break_ | _Break_ | _Break_ |
+| 10:45 - 12:00 | REST/CRUD| Mirador Community and Technology continued | -- |
+| 12:00 - 1:30  | _Lunch on your own_ | _Lunch on your own_ | _Lunch on your own_ |
+| 1:30 - 2:30   | Universal Viewer | A/V Use Cases | -- |
+| 2:30 - 3:30   | Universal Viewer continued | A/V Technical Solutions | End User Training |
+| 3:30 - 3:45   | _Break_ | _Break_ | _Break_ |
+| 3:45 - 5:00   | Universal Viewer continued | A/V Technical Solutions continued | IIIF Primer |
+{: .api-table .msched-table}
+
+#### Friday, October 21
+
+| Time          | Room A       | Room B/C     | Room D     |
+|---------------|---------------|-------------|-------------|
+| 8:30 - 9:00   | _Coffee_ | _Coffee_ | _Coffee_ |
+| 9:00 - 10:30  | Authentication API Deep Dive | Content Communities/Archives | -- |
+| 10:30 - 10:45 | _Break_ | _Break_ | _Break_ |
+| 10:45 - 12:00 | --| Community and Communications Plenary | -- |
+| 12:00 - 1:30  | _Lunch on your own_ | _Lunch on your own_ | _Lunch on your own_ |
+| 1:30 - 3:30   | Newspapers Interest Group | Shared Canvas 2.0/Presentation API 3.0 | Museums Interest Group |
+| 3:30 - 3:45   | _Break_ | _Break_ | _Break_ |
+| 3:45 - 5:00   | -- | Wrap-up, Retrospective, and IIIF Goals for 2017 | -- |
+{: .api-table .msched-table}
 
 
 [home-page]: http://iiif.io/


### PR DESCRIPTION
Added full schedule including lightning talks to the Event page for The Hague, see http://hague_sched_full.iiif.io/event/2016/thehague/#schedule