### PR TITLE
Fix line spacing for alert and note blocks, add space after strong

### DIFF
--- a/source/css/spec-doc2.scss
+++ b/source/css/spec-doc2.scss
@@ -129,6 +129,7 @@
       strong {
         font-weight: bold;
         color: #E05252;
+	margin-right: 10px;
       }
     }
     .alert {
@@ -141,10 +142,9 @@
       vertical-align: top;
 
       strong {
-        line-height: 35px;
         font-weight: bold;
         color: #B9AB2D;
-        margin-bottom: 10px;
+	margin-right: 10px;
       }
     }
 
@@ -158,10 +158,9 @@
       vertical-align: top;
 
       strong {
-        line-height: 35px;
         font-weight: bold;
         color: #32C032;
-        margin-bottom: 10px;
+	margin-right: 10px;
       }
     }
 


### PR DESCRIPTION
It seems that the line spacing for the `<strong>` in `.warning` blocks was fixed sometime earlier but has been broken (leading to large space to following line) for `.alert` and `.note` blocks. Change fixes that and adds a little extra space between the end of the `<strong>` block and following text because we don't seem to put any punctuation in there.