### PR TITLE
Fix protocol URI in image frame

### DIFF
--- a/source/api/image/2/info_frame.json
+++ b/source/api/image/2/info_frame.json
@@ -3,5 +3,5 @@
 {
   "@context": "http://iiif.io/api/image/2/context.json",
   "@embed": "true",
-  "protocol": "http://iiif.io/api/image/"
+  "protocol": "http://iiif.io/api/image"
 }


### PR DESCRIPTION
The current Image API [JSON-LD frame](http://iiif.io/api/image/2/info_frame.json) specifies:

``` json
  "protocol": "http://iiif.io/api/image/"
```

whereas the [Image API spec](http://iiif.io/api/image/2.1/#technical-properties) defines it as `http://iiif.io/api/image` (no trailing slash). Since the spec is normative and the frame is not (and obviously nobody using in anger since this error results in `protocol` missing from framed output), the solution is simply to update the frame.
