### PR TITLE
Av group page update

### DIFF
--- a/source/community/groups/av/index.md
+++ b/source/community/groups/av/index.md
@@ -22,11 +22,11 @@ The IIIF A/V Technical Specification Group aims to extend to A/V the benefits of
 [iiif-conf-2016]: /event/2016/newyork/#wednesday "IIIF Conference 2016"
 [events]: /event "IIIF Events"
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss "IIIF-Discuss Forum"
-[av-slack]: [https://iiif.slack.com/messages/av/details/]
-[av-folder]: [https://drive.google.com/drive/folders/0B8SS5OUXWs4GZ0ZfbEhIclhzb0k?usp=sharing]
-[slack]: [http://bit.ly/iiif-slack]
-[https://bluejeans.com/608386174]: [https://bluejeans.com/608386174]
-[iiif-calendar]: [http://iiif.io/community/groups/]
+[av-slack]: https://iiif.slack.com/messages/av/details/
+[av-folder]: https://drive.google.com/drive/folders/0B8SS5OUXWs4GZ0ZfbEhIclhzb0k?usp=sharing
+[slack]: http://bit.ly/iiif-slack
+[https://bluejeans.com/608386174]: https://bluejeans.com/608386174
+[iiif-calendar]: http://iiif.io/community/groups/
 
 
 {% include acronyms.md %}

--- a/source/community/groups/av/index.md
+++ b/source/community/groups/av/index.md
@@ -1,24 +1,32 @@
 ---
-title: "IIIF A/V Working Group"
+title: "IIIF A/V Technical Specification Group"
 layout: spec
 tags: []
 cssversion: 2
 ---
 
-The IIIF A/V Working Group aims to extend to A/V the benefits of interoperability and the growing ecosystem of clients and servers that IIIF provides for images. The working group was formed following a workshop hosted by the British Library to gather [use cases for extending IIIF to audio and video][bl-workshop-2016-04], and discussion at the [2016 IIIF Conference][iiif-conf-2016].
+## About
+
+The IIIF A/V Technical Specification Group aims to extend to A/V the benefits of interoperability and the growing ecosystem of clients and servers that IIIF provides for images. The A/V specification group was formed following a workshop hosted by the British Library to gather [use cases for extending IIIF to audio and video][bl-workshop-2016-04], and discussion at the [2016 IIIF Conference][iiif-conf-2016] in New York City. At the Fall 2016 working meeting in The Hague, the group focused on determining an initial set of features. The A/V group welcomes contributions to their collection of [audiovisual user stories][av-user-stories] and mockups and prototypes.
 
 ## Organization
 
-  * Chair: Jason Ronallo (NCSU Libraries)
-  * Virtual meetings will be announced on [IIIF-Discuss][iiif-discuss]
-  * Communicate via [IIIF-Discuss][iiif-discuss]
-  * Collect and organize [audiovisual user stories][av-user-stories]
+  * **Chair:** Jason Ronallo (North Carolina State University Libraries)
+  * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# av IIIF Slack channel][av-slack] ([Join Slack][slack])
+  * **Call Notes and Group Documents:** [IIIF A/V Tech Spec Group folder][av-folder]
+  * **Regular Call Schedule:** Every other week (opposite the general IIIF Community Call) on Tuesdays at 12:00pm Eastern - see [IIIF Community Calendar][iiif-calendar] for details
+  * **Call Connection Information:** Connect Online at [https://bluejeans.com/608386174][https://bluejeans.com/608386174] or by Phone: +1.408.740.7256 (US)/ +1.888.240.2560 (US Toll Free)/ +1.408.317.9253 - Enter Meeting ID: 608386174
 
 [av-user-stories]: https://github.com/IIIF/iiif-av/issues "Audiovisual User Stories"
 [bl-workshop-2016-04]: https://goo.gl/iVXEFD "Use cases and notes from April 2015 workshop at British Library"
 [iiif-conf-2016]: /event/2016/newyork/#wednesday "IIIF Conference 2016"
 [events]: /event "IIIF Events"
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss "IIIF-Discuss Forum"
+[av-slack]: [https://iiif.slack.com/messages/av/details/]
+[av-folder]: [https://drive.google.com/drive/folders/0B8SS5OUXWs4GZ0ZfbEhIclhzb0k?usp=sharing]
+[slack]: [http://bit.ly/iiif-slack]
+[https://bluejeans.com/608386174]: [https://bluejeans.com/608386174]
+[iiif-calendar]: [http://iiif.io/community/groups/]
 
 
 {% include acronyms.md %}


### PR DESCRIPTION
In an effort to provide consistent information across all IIIF groups (the A/V group was first to comply) - working with Jason, I added additional info to the group page to make it easier to learn more and get involved with the group - see changes http://av_group_page_update.iiif.io/community/groups/av/ 
Closes #950 