### PR TITLE
added standard info to software devs group page

### DIFF
--- a/source/community/groups/software/index.md
+++ b/source/community/groups/software/index.md
@@ -1,10 +1,12 @@
 ---
-title: "Software Developers Interest Group"
+title: "Software Developers Community Group"
 layout: spec
 tags: [components, software development, implementation]
 cssversion: 2
 ---
-The Software Developers Interest Group formed in response to the growing need for shared, composable libraries for IIIF viewer software following the IIIF Meeting in New York in May 2016. Software developers from several institutions involved in developing user experiences on top of the IIIF APIs were duplicating each other’s efforts and finding it difficult to consistently apply the specifications.
+## About
+
+The Software Developers Community Group formed in response to the growing need for shared, composable libraries for IIIF viewer software following the IIIF Meeting in New York in May 2016. Software developers from several institutions involved in developing user experiences on top of the IIIF APIs were duplicating each other’s efforts and finding it difficult to consistently apply the specifications.
 
 As the IIIF developer community grows, it continues to have a greater need for reusable components that can be composed into special-purpose applications. In the interest of keeping pace with improvement to the Image and Presentation API specifications, as well as the introduction of new APIs, the interest group provides a vehicle for developers from multiple institutions to discuss, develop, and curate a collection of software components that adhere to certain standards of software quality, composability, and specification compliance.
 
@@ -18,8 +20,19 @@ To advance the growth and adoption of interoperable software with IIIF, the Soft
 * Develop opportunities and development practices for sustainable collaboration efforts across institutions and funding resources.
 
 ## Organization
-* Chairs: Rashmi Singhal (Harvard University) and Drew Winget (Stanford University)
-* Virtual meetings announced on IIIF-Discuss
-* Group notes in IIIF Software Developers Folder
+* **Chairs:** Rashmi Singhal (Harvard University) and Drew Winget (Stanford University)
+* **Communication Channels:** Virtual meetings announced on [IIIF-Discuss][iiif-discuss]. General discussion on the [# softwaredevs IIIF Slack channel][devs-slack] ([Join Slack][join-slack])
+* **Call Notes and Group Documents:** [IIIF Software Developers Folder][devs-folder]
+* **Regular Meeting Schedule:** Every other week (opposite the general IIIF Community Call) on Wednesdays at 12:00pm Eastern - see [IIIF Community Calendar][calendar] for details
+* **Call Connection Information:** Connect online at [https://bluejeans.com/782319325][bluejeans] or by Phone: +1.408.740.7256 (US)/ +1.888.240.2560 (US Toll Free)/ +1.408.317.9253 - Enter Meeting ID: 782319325
+
+
+[iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss
+[devs-slack]: https://iiif.slack.com/messages/softwaredevs/details/
+[join-slack]: http://bit.ly/iiif-slack
+[devs-folder]: https://drive.google.com/drive/folders/0B8WLA_XCC1koZUF6TEFmQW5Vc0E?usp=sharing
+[calendar]: http://iiif.io/community/groups/
+[bluejeans]: https://bluejeans.com/782319325
+
 
 {% include acronyms.md %}


### PR DESCRIPTION
added standardized "organization" fields to the software devs group page: http://devs_group_update.iiif.io/community/groups/software/ 

Closes #974 