### PR TITLE
general improvements to community page

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -7,6 +7,39 @@ redirect_from:
   - /community.html
 ---
 
+          <section id="intro" class="intro wrapper">
+            <div>The International Image Interoperability Framework (IIIF) encompasses a large and growing community of interested individuals and organizations and a <a href="http://iiif.io/community/consortium/">Consortium</a> (IIIF Consortium or IIIF-C) of institutions dedicated to leading and sustaining the IIIF. As a community-driven initiative, IIIF thrives on active discussion, input, and feedback from a wide array of diverse individuals from libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to get involved. All participants in all IIIF activities are expected to follow the <a href="/event/conduct">IIIF code of conduct</a>.</div>
+          </section>
+
+          <section id="how-to-get-involved" class="get-involved wrapper">
+            <h2>How to get involved</h2>
+            <div>Join our discussion list:
+            <pre style="padding-left: 30px"><a href="https://groups.google.com/forum/#!forum/iiif-discuss" target="_blank">https://groups.google.com/forum/#!forum/iiif-discuss</a></pre>
+            </div>
+
+            <div>Sign up to receive IIIF announcements on the lower traffic announcements list:
+            	<pre style="padding-left: 30px"><a href="https://groups.google.com/forum/#!forum/iiif-announce" target="_blank">https://groups.google.com/forum/#!forum/iiif-announce</a></pre></div>
+
+            <div>Explore the IIIF community GitHub page:
+            	<pre style="padding-left: 30px"><a href="http://github.com/iiif">http://github.com/iiif</a></pre></div>
+
+            <div>Share ideas in the IIIF Slack team:
+                <pre style="padding-left: 30px"><a href="http://bit.ly/iiif-slack">http://bit.ly/iiif-slack</a></pre></div>
+
+            <div>Attend a IIIF Event:
+                <pre style="padding-left: 30px"><a href="http://iiif.io/event/">http://iiif.io/event/</a></pre></div>
+
+            <div>Participate in bi-weekly teleconferences. Call connection details are posted in the <a href="https://groups.google.com/forum/#!forum/iiif-discuss">iiif-discuss list</a>.
+                <pre style="padding-left: 30px"></div>
+
+            <div>The schedule for IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</div>
+          </section>
+
+          <section id="community-groups" class="quick-start wrapper">
+            <h2>Community groups</h2>
+            <div>There are a number of <a href="groups/">community and technical groups</a>, open to participation from all interested parties, that focus on different areas of interest related to IIIF.</div>
+          </section>
+
           <section class="participants wrapper">
             <h2>Participating Institutions</h2>
             <p>The IIIF community consists of a rapidly growing number of cultural heritage institutions and open source software companies and projects committed to sharing and displaying image resources across repositories and the web. Participating institutions include, with members of the <a href="consortium/">IIIF Consortium</a> marked in bold:</p>
@@ -21,38 +54,4 @@ redirect_from:
               </li>
             {% endfor %}
             </ul>
-          </section>
-
-          <section id="how-to-get-involved" class="get-involved wrapper">
-            <h2>How to get involved</h2>
-            <div>We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to join our discussion list at:
-            <pre style="padding-left: 30px"><a href="https://groups.google.com/forum/#!forum/iiif-discuss" target="_blank">https://groups.google.com/forum/#!forum/iiif-discuss</a></pre>
-            </div>
-
-            <div>There is also a lower traffic announcements list at:
-            	<pre style="padding-left: 30px"><a href="https://groups.google.com/forum/#!forum/iiif-announce" target="_blank">https://groups.google.com/forum/#!forum/iiif-announce</a></pre></div>
-
-            <div>The IIIF community GitHub page is at:
-            	<pre style="padding-left: 30px"><a href="http://github.com/iiif">http://github.com/iiif</a></pre></div>
-
-            <div>
-              Join the conversation on the IIIF Slack team:
-                <pre style="padding-left: 30px"><a href="http://bit.ly/iiif-slack">http://bit.ly/iiif-slack</a></pre>
-            </div>
-
-            <div>
-              Attend a IIIF Event:
-                <pre style="padding-left: 30px"><a href="http://iiif.io/event/">http://iiif.io/event/</a></pre>
-            </div>
-
-            <div>There are also bi-weekly teleconferences, the details of which are posted in the iiif-discuss list. All community members are welcome and encouraged to participate in the calls.  All IIIF call notes and working documents can be accessed from the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</div>
-          </section>
-
-          <section id="community-groups" class="quick-start wrapper">
-            <h2>Community groups</h2>
-            <div>There are a number of <a href="groups/">community and technical groups</a>, open to participation from all interested parties, that focus on different areas of interest related to IIIF.</div>
-          </section>
-
-          <section id="conduct" class="wrapper">
-            <div>All participants in all IIIF activities are expected to follow the <a href="/event/conduct">IIIF code of conduct</a>.</div>
           </section>

--- a/source/community/index.html
+++ b/source/community/index.html
@@ -29,10 +29,8 @@ redirect_from:
             <div>Attend a IIIF Event:
                 <pre style="padding-left: 30px"><a href="http://iiif.io/event/">http://iiif.io/event/</a></pre></div>
 
-            <div>Participate in bi-weekly teleconferences. Call connection details are posted in the <a href="https://groups.google.com/forum/#!forum/iiif-discuss">iiif-discuss list</a>.
-                <pre style="padding-left: 30px"></div>
-
-            <div>The schedule for IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</div>
+            <div>Participate in bi-weekly teleconferences. Call connection details are posted in the <a href="https://groups.google.com/forum/#!forum/iiif-discuss">iiif-discuss list</a>.</div>
+            <div><p>The schedule for IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</p></div>
           </section>
 
           <section id="community-groups" class="quick-start wrapper">


### PR DESCRIPTION
As noted in https://github.com/IIIF/iiif.io/pull/965 as well as indicated in verbal feedback from multiple individuals, the long list of community institutions was previously hindering access to information about how to engage with the IIIF community. I'm hoping this iteration makes the information more accessible and more clear for the time being, note specifically:

- Intro sentences describing the community
- Bringing code of conduct up into intro
- How to get involved front and center
- Action words for each type of engagement
- calendar and google drive linked
- participating institutions list at the bottom

I'm open to feedback. Thanks!
