### PR TITLE
added Europeana and Kyoto University to IIIF-C list

### DIFF
--- a/source/_data/institutions.yml
+++ b/source/_data/institutions.yml
@@ -53,6 +53,7 @@
   uri:  http://www.e-codices.unifr.ch
 - name: Europeana
   uri: http://europeana.eu/
+  iiifc: 2
 - name: The J. Paul Getty Trust
   uri: http://getty.edu/
   iiifc: 2
@@ -76,6 +77,9 @@
   iiifc: 2
 - name: Klokan Technologies
   uri: http://www.klokantech.com/
+- name: Kyoto University Library Network
+  uri:
+  iiifc: 2
 - name: Leiden University
   uri:
   iiifc: 2


### PR DESCRIPTION
See http://add_europeana_kyoto.iiif.io/community/consortium/#members

closes #988 and closes #989 

This list is finally up to date - we have 39 IIIF-C members (Yale is listed as two entities but they are technically one member)