### PR TITLE
added first newsletter to news

### DIFF
--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -11,4 +11,7 @@
     <link rel="stylesheet" href="/css/main.css">
     <link type="application/atom+xml" rel="alternate" href="/news/atom.xml"/>
     <script src="/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>
+    <script src="https://code.jquery.com/jquery-2.2.3.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous"></script>
+    <script src="/js/vendor/anchor.min.js"></script>
+    <script src="/js/anchor.js"></script>
   </head>

--- a/source/_posts/2016-11-15-newsletter.md
+++ b/source/_posts/2016-11-15-newsletter.md
@@ -11,7 +11,7 @@ excerpt: >
 
 ## Community Snapshot
  * [IIIF-Discuss][iiif-discuss] = 568 members  
- * IIIF Slack = 202 members ([Join Slack][join-slack])  
+ * [IIIF Slack][join-slack] = 202 members  
  * [IIIF Consortium][iiif-c]  = 39 members  
  * IIIF is now seeking a dedicated staff member for the role of [IIIF Technology Coordinator][tech-coordinator]  
 

--- a/source/_posts/2016-11-15-newsletter.md
+++ b/source/_posts/2016-11-15-newsletter.md
@@ -4,32 +4,35 @@ author: Sheila Rabun
 date: 2016-11-15
 tags: [news, newsletter, announcements]
 layout: post
+excerpt: >
+  Community Snapshot, Community Events, Technical Work, Museums Community Group,
+  Implementations and Adoption
 ---
 
-# **Community Snapshot:**
+## Community Snapshot
  * [IIIF-Discuss][iiif-discuss] = 568 members  
  * IIIF Slack = 202 members ([Join Slack][join-slack])  
  * [IIIF Consortium][iiif-c]  = 39 members  
  * IIIF is now seeking a dedicated staff member for the role of [IIIF Technology Coordinator][tech-coordinator]  
 
-# **Community Events:**
+## Community Events
 
-## **IIIF Working Meeting in The Hague**
+### IIIF Working Meeting in The Hague
 The recent IIIF Working Meeting, hosted by Europeana at the Koninklijke Bibliotheek in The Hague (Oct. 19-21), provided an exciting forum for discussion, formulation of action items, and brainstorming for improvements to the IIIF community and technical frameworks.
 
  * Attendees: 61 participants from 29 cultural heritage institutions and technology firms
  * Review [Notes][hague-notes] from each of the working sessions
  * Explore the [Slides][hague-slides] from community Lightning Talk presentations
 
-## **Outreach Event in Amsterdam**
+### Outreach Event in Amsterdam
 The IIIF Outreach Event at the Rijksmuseum in Amsterdam (Oct. 18), sponsored in part by Europeana, drew a crowd of 42 interested individuals from museums, libraries, and software companies around Europe. Presentations focused on an overview of the IIIF community and technical specifications, and demonstrations of IIIF functionality in action.
 
 * View [Slides][outreach-slides] from the Outreach Event
 
-## **IIIF and IPTC Discuss Alliance**
+### IIIF and IPTC Discuss Alliance
 After the Working Meeting, the IIIF editors met with the [International Press Telecommunications Council][iptc], the standards body for news media, at their annual general meeting in Berlin.  The two organizations discussed the mutual benefits of each other’s work and agreed to continue working towards technical integration and co-promotion across the two communities.
 
-## **IIIF Presence at Conferences and Meetings**
+### IIIF Presence at Conferences and Meetings
 Active community participants are encouraged to represent IIIF at conferences, workshops and events around the world. Those planning to present on IIIF at a conference or meeting, please fill out the “[IIIF Representation at Conferences and Meetings][outreach-survey]” Survey. Recent and upcoming IIIF appearances include:
 
  * Hydra Connect, October 2016
@@ -40,41 +43,41 @@ Active community participants are encouraged to represent IIIF at conferences, w
  * Coalition for Networked Information (CNI), December 2016
  * Linked Pasts 2016, December 2016  
 
-## **2nd Annual IIIF Conference**
+### 2nd Annual IIIF Conference
 Save the date: the next IIIF Conference is scheduled for the week of June 5, 2017, in The Vatican. Stay tuned to the [IIIF Events page][iiif-events] and email announcements via the [IIIF-Discuss][iiif-discuss] email list for more details.
 
-# **Technical Work:**
+## Technical Work
 
-## **A/V Technical Specification Work**
+### A/V Technical Specification Work
 After a productive [meeting in The Hague][av-notes], the IIIF Audio/Visual Technical Specification Group is currently seeking questions, feedback, mock-ups, and prototypes for the production of a IIIF A/V API. All interested parties are encouraged to get involved at varied levels of commitment. See the [A/V group page][iiif-av] for details on how to join in the discussion and learn more.
 
-## **Discovery of IIIF Resources**
+### Discovery of IIIF Resources
 Interoperable resources are only useful if they can be found. The community is launching a concerted effort to improve the IIIF resource discovery process, with a focus on leveraging existing techniques and tools. Next steps include gathering use cases and requirements and creating an initial implementation plan. Follow discussions on the [IIIF-Discuss][iiif-discuss] email list. For more information, see the Discovery [overview][disc-overview] and [technical][disc-technical] discussion notes from The Hague.
 
-## **IIIF Authentication API**
+### IIIF Authentication API
 The prospective [IIIF Authentication API][iiif-auth] is currently under review by the IIIF community, with a few questions remaining the be answered. Continuing discussions will ensue on the [IIIF-Discuss][iiif-discuss] email list and on upcoming community calls (see the [IIIF Community Calendar][iiif-calendar] for call details). For additional information, see the [Authentication meeting notes][auth-notes] from The Hague.
 
-## **Shared Canvas 2.0**
+### Shared Canvas 2.0
 [Shared Canvas][shared-canvas] is the data model that underlies the IIIF technical specifications. [Discussions in the Hague][shared-canvas-hague] focused on updating the Shared Canvas model to address the latest developments and advances in IIIF. This will serve to ensure alignment of the two efforts, especially as IIIF extends to A/V materials.
 
-# **Community Groups:**
+## Community Groups:
 Please see the [IIIF Community Groups page][iiif-calendar] for a calendar of group and community calls, as well as links to more information about each group.
 
-## **Manuscripts Community Group**
+### Manuscripts Community Group
 With the goal of promoting increased accessibility to world manuscript images via the IIIF APIs, the [IIIF Manuscripts community group][manuscripts] shares regular project updates and demonstrations of ever-improving functionality for digital manuscript research. Current shared interests include additions to functionality for scholarly data in the Mirador viewer, creating custom manifests from multiple image sources, and developing IIIF plugins for existing platforms such as Omeka.
 
-## **Museums Community Group**
+### Museums Community Group
 Several museums have recognized the benefits of IIIF for museum images, and the [IIIF Museums community group][museums] is leading the effort to reach out to the wider museums community. Next steps include compiling outreach and training materials specifically geared toward the museums community, and continued IIIF-based presentations at museum conferences.
 
-## **Newspapers Community Group**
+### Newspapers Community Group
 The [IIIF Newspapers community group][newspapers] has drafted [guidelines for implementing IIIF][newspaper-guidelines] specifically for digital newspapers and the IIIF Presentation API. A number of institutions have successfully implemented one or more of the IIIF APIs for digital newspaper collections, with additional implementations underway.
 
-## **Software Developers Community Group**
+### Software Developers Community Group
 A forum for sharing IIIF-related implementation questions, updates, and demos, the [IIIF Software Developers community group][devs] welcomes front end designers, back end developers, and usability experts. The group is currently documenting a set of software components that improve the developer experience and support productivity with the IIIF APIs. They are also building up a body of running, live examples of how existing components can be configured, composed, and wired up so developers can hit the ground running from a working foundation.
 
-# **Implementations and Adoption:**
+## Implementations and Adoption
 
-## **New Releases**
+### New Releases
 
  * [Mirador 2.1][mirador], with significant feature enhancements & more IIIF support
  * [Manifest editor tool][manifest-editor] – Oxford University, with Text and Bytes, has produced a tool to create, upload and edit IIIF manifests; there is a version installed at the [Bodleian][bodleian-editor]
@@ -83,7 +86,7 @@ A forum for sharing IIIF-related implementation questions, updates, and demos, t
  * [CONTENTdm][contentdm] has announced support for IIIF Image API in their next release, adding 20 million resources to the IIIF Universe
  * [LUNA][luna-iiif] now supports both the IIIF Image and Presentation APIs
 
-## **Innovations & Ongoing Work from Across the IIIF Community**
+### Innovations & Ongoing Work from Across the IIIF Community
 
  * [Stanford drag and drop][stanford-dnd] (plus tutorial video)
  * [NCSU newspapers with IIIF Search API][ncsu-search]
@@ -91,10 +94,10 @@ A forum for sharing IIIF-related implementation questions, updates, and demos, t
  * [Palette extraction tool][palette-service] – Image API service for palette extraction
  * [pontIIIF][pontiiif], a prototype IIIF crawler and search engine, from Brumfield Labs
 
-### **Edited by:**
+#### Edited by:
 Sheila Rabun, IIIF Community and Communications Officer
 
-### **With contributions from:**
+#### With contributions from:
 Michael Appleby (Yale Center for British Art)  
 Tom Cramer (Stanford University Libraries)  
 Karen Estlund (Pennsylvania State University Libraries)  

--- a/source/_posts/2016-11-15-newsletter.md
+++ b/source/_posts/2016-11-15-newsletter.md
@@ -1,0 +1,142 @@
+---
+title: IIIF Community Newsletter, Volume 1 Issue 1
+author: Sheila Rabun
+date: 2016-11-15
+tags: [news, newsletter, announcements]
+layout: post
+---
+
+# **Community Snapshot:**
+ * [IIIF-Discuss][iiif-discuss] = 568 members  
+ * IIIF Slack = 202 members ([Join Slack][join-slack])  
+ * [IIIF Consortium][iiif-c]  = 39 members  
+ * IIIF is now seeking a dedicated staff member for the role of [IIIF Technology Coordinator][tech-coordinator]  
+
+# **Community Events:**
+
+## **IIIF Working Meeting in The Hague**
+The recent IIIF Working Meeting, hosted by Europeana at the Koninklijke Bibliotheek in The Hague (Oct. 19-21), provided an exciting forum for discussion, formulation of action items, and brainstorming for improvements to the IIIF community and technical frameworks.
+
+ * Attendees: 61 participants from 29 cultural heritage institutions and technology firms
+ * Review [Notes][hague-notes] from each of the working sessions
+ * Explore the [Slides][hague-slides] from community Lightning Talk presentations
+
+## **Outreach Event in Amsterdam**
+The IIIF Outreach Event at the Rijksmuseum in Amsterdam (Oct. 18), sponsored in part by Europeana, drew a crowd of 42 interested individuals from museums, libraries, and software companies around Europe. Presentations focused on an overview of the IIIF community and technical specifications, and demonstrations of IIIF functionality in action.
+
+* View [Slides][outreach-slides] from the Outreach Event
+
+## **IIIF and IPTC Discuss Alliance**
+After the Working Meeting, the IIIF editors met with the [International Press Telecommunications Council][iptc], the standards body for news media, at their annual general meeting in Berlin.  The two organizations discussed the mutual benefits of each other’s work and agreed to continue working towards technical integration and co-promotion across the two communities.
+
+## **IIIF Presence at Conferences and Meetings**
+Active community participants are encouraged to represent IIIF at conferences, workshops and events around the world. Those planning to present on IIIF at a conference or meeting, please fill out the “[IIIF Representation at Conferences and Meetings][outreach-survey]” Survey. Recent and upcoming IIIF appearances include:
+
+ * Hydra Connect, October 2016
+ * IPTC Annual General Meeting, October 2016
+ * Museum Computer Network (MCN), November 2016
+ * Digital Library Forum (DLF), November 2016
+ * 9th Annual Lawrence J. Schoenberg Symposium on Manuscript Studies in the Digital Age, November 2016
+ * Coalition for Networked Information (CNI), December 2016
+ * Linked Pasts 2016, December 2016  
+
+## **2nd Annual IIIF Conference**
+Save the date: the next IIIF Conference is scheduled for the week of June 5, 2017, in The Vatican. Stay tuned to the [IIIF Events page][iiif-events] and email announcements via the [IIIF-Discuss][iiif-discuss] email list for more details.
+
+# **Technical Work:**
+
+## **A/V Technical Specification Work**
+After a productive [meeting in The Hague][av-notes], the IIIF Audio/Visual Technical Specification Group is currently seeking questions, feedback, mock-ups, and prototypes for the production of a IIIF A/V API. All interested parties are encouraged to get involved at varied levels of commitment. See the [A/V group page][iiif-av] for details on how to join in the discussion and learn more.
+
+## **Discovery of IIIF Resources**
+Interoperable resources are only useful if they can be found. The community is launching a concerted effort to improve the IIIF resource discovery process, with a focus on leveraging existing techniques and tools. Next steps include gathering use cases and requirements and creating an initial implementation plan. Follow discussions on the [IIIF-Discuss][iiif-discuss] email list. For more information, see the Discovery [overview][disc-overview] and [technical][disc-technical] discussion notes from The Hague.
+
+## **IIIF Authentication API**
+The prospective [IIIF Authentication API][iiif-auth] is currently under review by the IIIF community, with a few questions remaining the be answered. Continuing discussions will ensue on the [IIIF-Discuss][iiif-discuss] email list and on upcoming community calls (see the [IIIF Community Calendar][iiif-calendar] for call details). For additional information, see the [Authentication meeting notes][auth-notes] from The Hague.
+
+## **Shared Canvas 2.0**
+[Shared Canvas][shared-canvas] is the data model that underlies the IIIF technical specifications. [Discussions in the Hague][shared-canvas-hague] focused on updating the Shared Canvas model to address the latest developments and advances in IIIF. This will serve to ensure alignment of the two efforts, especially as IIIF extends to A/V materials.
+
+# **Community Groups:**
+Please see the [IIIF Community Groups page][iiif-calendar] for a calendar of group and community calls, as well as links to more information about each group.
+
+## **Manuscripts Community Group**
+With the goal of promoting increased accessibility to world manuscript images via the IIIF APIs, the [IIIF Manuscripts community group][manuscripts] shares regular project updates and demonstrations of ever-improving functionality for digital manuscript research. Current shared interests include additions to functionality for scholarly data in the Mirador viewer, creating custom manifests from multiple image sources, and developing IIIF plugins for existing platforms such as Omeka.
+
+## **Museums Community Group**
+Several museums have recognized the benefits of IIIF for museum images, and the [IIIF Museums community group][museums] is leading the effort to reach out to the wider museums community. Next steps include compiling outreach and training materials specifically geared toward the museums community, and continued IIIF-based presentations at museum conferences.
+
+## **Newspapers Community Group**
+The [IIIF Newspapers community group][newspapers] has drafted [guidelines for implementing IIIF][newspaper-guidelines] specifically for digital newspapers and the IIIF Presentation API. A number of institutions have successfully implemented one or more of the IIIF APIs for digital newspaper collections, with additional implementations underway.
+
+## **Software Developers Community Group**
+A forum for sharing IIIF-related implementation questions, updates, and demos, the [IIIF Software Developers community group][devs] welcomes front end designers, back end developers, and usability experts. The group is currently documenting a set of software components that improve the developer experience and support productivity with the IIIF APIs. They are also building up a body of running, live examples of how existing components can be configured, composed, and wired up so developers can hit the ground running from a working foundation.
+
+# **Implementations and Adoption:**
+
+## **New Releases**
+
+ * [Mirador 2.1][mirador], with significant feature enhancements & more IIIF support
+ * [Manifest editor tool][manifest-editor] – Oxford University, with Text and Bytes, has produced a tool to create, upload and edit IIIF manifests; there is a version installed at the [Bodleian][bodleian-editor]
+ * [From the Page][from-the-page] transcription tool has integrated IIIF support for images and annotations (See details for [From the Page/IIIF][from-the-page-iiif])
+ * [Diva.js 5.0][diva] viewer now includes enhanced IIIF support
+ * [CONTENTdm][contentdm] has announced support for IIIF Image API in their next release, adding 20 million resources to the IIIF Universe
+ * [LUNA][luna-iiif] now supports both the IIIF Image and Presentation APIs
+
+## **Innovations & Ongoing Work from Across the IIIF Community**
+
+ * [Stanford drag and drop][stanford-dnd] (plus tutorial video)
+ * [NCSU newspapers with IIIF Search API][ncsu-search]
+ * [Europeana sitemaps discovery mechanism][europeana-sitemaps]
+ * [Palette extraction tool][palette-service] – Image API service for palette extraction
+ * [pontIIIF][pontiiif], a prototype IIIF crawler and search engine, from Brumfield Labs
+
+### **Edited by:**
+Sheila Rabun, IIIF Community and Communications Officer
+
+### **With contributions from:**
+Michael Appleby (Yale Center for British Art)  
+Tom Cramer (Stanford University Libraries)  
+Karen Estlund (Pennsylvania State University Libraries)  
+Jason Ronallo (North Carolina State University Libraries)  
+Rob Sanderson (J. Paul Getty Trust)  
+Drew Winget (Stanford University Libraries)  
+
+
+[iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss
+[join-slack]: http://bit.ly/iiif-slack
+[iiif-c]: http://iiif.io/community/consortium/
+[tech-coordinator]: https://www.clir.org/about/positions/iiif_technology_coordinator
+[hague-notes]: https://drive.google.com/drive/folders/0B8biwZuDijgednFqMG91WDZjdUE
+[hague-slides]: https://drive.google.com/drive/folders/0B8biwZuDijgeWktQSk9pd0pqNTA
+[outreach-slides]: https://drive.google.com/drive/folders/0B8biwZuDijgeUDJLY3hoREVTVEU
+[iptc]: https://iptc.org/
+[outreach-survey]: https://docs.google.com/forms/d/e/1FAIpQLScDBfjLTLsC4trMGVXETeEiU1oqNQZd3H9cDApO1jx2M18BBw/viewform?c=0&w=1
+[iiif-events]: http://iiif.io/event/
+[av-notes]: https://docs.google.com/document/d/1cnkOPm7rC9uKeSxorFpu004ZzJxolVLWex5NdxMKnHY/edit?usp=sharing
+[iiif-av]: http://iiif.io/community/groups/av/
+[disc-overview]: https://docs.google.com/document/d/1sqn61RAYH2fyc2Bh_ERzT8fA-_HwUDio6O1tSpicfyc/edit?usp=sharing
+[disc-technical]: https://docs.google.com/document/d/16_n_CCY9cuIPC_tAdkA-WbsKJpugZKk5GeEajpXA0CQ/edit?usp=sharing
+[iiif-auth]: http://iiif.io/api/auth/0.9/
+[iiif-calendar]: http://iiif.io/community/groups/
+[auth-notes]: https://docs.google.com/document/d/1k_q1gCC_CGqE-DavRlxU1FP7TgC70eHVO_UAWgKlX0E/edit?usp=sharing
+[shared-canvas]: http://iiif.io/model/shared-canvas/1.0/
+[shared-canvas-hague]: https://docs.google.com/document/d/1pfArbdTDOoS0ufKKiknyWLnEhi5CNENcakasN2-ugb8/edit?usp=sharing
+[manuscripts]: http://iiif.io/community/groups/manuscripts/
+[museums]: http://iiif.io/community/groups/museums/
+[newspapers]: http://iiif.io/community/groups/newspapers
+[devs]: http://iiif.io/community/groups/software/
+[newspaper-guidelines]: https://docs.google.com/document/d/1rz-Dm_LMguPD_Zi6Z1uf61XaPrdhd3mgK9_SV3EBdlE/edit?usp=sharing
+[mirador]: http://iiif.io/news/2016/09/16/mirador-upgrade-released/
+[manifest-editor]: http://morning-journey-27147.herokuapp.com/#/?_k=agcbor
+[bodleian-editor]: http://iiif.bodleian.ox.ac.uk/manifest-editor/#/?_k=g92i8r
+[from-the-page]: http://fromthepage.com/
+[from-the-page-iiif]: https://github.com/benwbrum/fromthepage/wiki/Documentary-Editing-for-IIIF-using-FromThePage
+[diva]: https://groups.google.com/forum/#!searchin/iiif-discuss/diva.js$205.0%7Csort:relevance/iiif-discuss/eVJn2qEHUX4/xopzl7pLBgAJ
+[contentdm]: https://groups.google.com/forum/#!searchin/iiif-discuss/contentdm%7Csort:relevance/iiif-discuss/zf5rC1YMI34/F2kdlw0HCQAJ
+[luna-iiif]: http://www.lunaimaging.com/iiif/
+[stanford-dnd]: https://library.stanford.edu/blogs/digital-library-blog/2016/08/iiif-in-searchworks
+[ncsu-search]: https://www.youtube.com/watch?v=gPRPfPZnIvU
+[europeana-sitemaps]: https://groups.google.com/forum/#!searchin/iiif-discuss/europeana$20discovery%7Csort:relevance/iiif-discuss/Y42yd2hjkjM/llKIlJZiBwAJ
+[palette-service]: http://palette.davidnewbury.com/
+[pontiiif]: https://www.youtube.com/watch?v=v2-3hAtidUM

--- a/source/css/main.scss
+++ b/source/css/main.scss
@@ -839,13 +839,13 @@ a.button-turquoise {
   .sub-pages-container .api-table th {
     white-space: nowrap;
   }
-  
-  
+
+
   .sub-pages-container .sched-table {
     width:100%;
   }
-  
-  
+
+
   .sub-pages-container .sched-table td:first-child {
     width: 20%;
   }
@@ -859,8 +859,8 @@ a.button-turquoise {
   .sub-pages-container .msched-table {
     width:100%;
   }
-  
-  
+
+
   .sub-pages-container .msched-table td:first-child {
     width: 13%;
   }
@@ -1042,6 +1042,9 @@ a.button-turquoise {
   }
 }
 .post {
+  h2, h3, h4 {
+    font-weight: 600;
+  }
   .meta {
     p {
       line-height: 1.1;
@@ -1054,5 +1057,9 @@ a.button-turquoise {
       margin: 0;
       padding:0;
     }
+  }
+  li {
+    padding-bottom: 0 !important;
+    padding-top: 0 !important;
   }
 }


### PR DESCRIPTION
I put the first IIIF Community Newsletter in the News section so as to provide a publishing platform to point people to...I was able to check my changes, links, etc. locally, but now I'm a bit confused as to why the post isn't showing up for me here: http://news_newsletter.iiif.io/news/  - file saved in iiif.io/source/_posts/2016-11-15-newsletter.md

Aiming to send newsletter out via email and point people to news posting on Nov. 15...Thanks!