### PR TITLE
standardized newspapers group page and added meeting info

### DIFF
--- a/source/community/groups/newspapers/index.md
+++ b/source/community/groups/newspapers/index.md
@@ -1,9 +1,13 @@
 ---
-title: "IIIF Newspapers Interest Group"
+title: "IIIF Newspapers Community Group"
 layout: spec
 tags: []
 cssversion: 2
 ---
+
+## About
+
+The IIIF Newspapers Community Group welcomes participants with an interest in implementing IIIF in digital newspaper repositories. In addition to monthly meetings, the group also piggybacks on [IIIF face to face meetings][events]. Contributions to [newspapers user stories][user-stories] are welcome, and useful resources related to newspapers and IIIF can be found on [Awesome-IIIF][newspapers-awesome-iiif].
 
 ## Purpose
 
@@ -15,17 +19,21 @@ cssversion: 2
 
 ## Organization
 
-  * Chairs: Karen Estlund (Pennsylvania State University) and Glen Robson (National Library of Wales)
-  * Monthly virtual meetings (announced on [IIIF-Discuss][iiif-discuss], notes in [IIIF Newspapers Folder][newspapers-folder])
-  * Communicate via [IIIF-Discuss][iiif-discuss]
-  * Piggyback on [IIIF face to face meetings][events]
-  * Collect and organize [newspapers user strories][user-stories]
-  * Collect useful resources about [Newspapers on Awesome-IIIF][newspapers-awesome-iiif]
+  * **Chairs:** Karen Estlund (Pennsylvania State University) and Glen Robson (National Library of Wales)
+  * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# newspapers IIIF Slack channel][newspapers-slack] ([Join Slack][join-slack])
+  * **Call Notes and Group Documents:** [IIIF Newspapers Community Group Folder][newspapers-folder])
+  * **Regular Call Schedule:** Last Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
+  * **Call Connection Information:** Connect Online at [https://bluejeans.com/753929435][https://bluejeans.com/753929435] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 753929435
 
 [newspapers-awesome-iiif]: https://github.com/IIIF/awesome-iiif#newspapers "Newspapers on Awesome-IIIF"
 [events]: /event "IIIF Events"
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss "IIIF-Discuss Forum"
 [newspapers-folder]: https://goo.gl/jNFfVw "IIIF Newspapers Folder"
 [user-stories]: https://github.com/IIIF/iiif-stories/issues?q=is%3Aopen+is%3Aissue+label%3Anewspapers "Newspapers User Stories"
+[newspapers-slack]: https://iiif.slack.com/messages/newspapers/details/
+[join-slack]: http://bit.ly/iiif-slack
+[calendar]: http://iiif.io/community/groups/
+[https://bluejeans.com/753929435]: https://bluejeans.com/753929435
+[international-bluejeans]: https://bluejeans.com/numbers?ll=en
 
 {% include acronyms.md %}

--- a/source/community/groups/newspapers/index.md
+++ b/source/community/groups/newspapers/index.md
@@ -21,8 +21,8 @@ The IIIF Newspapers Community Group welcomes participants with an interest in im
 
   * **Chairs:** Karen Estlund (Pennsylvania State University) and Glen Robson (National Library of Wales)
   * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# newspapers IIIF Slack channel][newspapers-slack] ([Join Slack][join-slack])
-  * **Call Notes and Group Documents:** [IIIF Newspapers Community Group Folder][newspapers-folder])
-  * **Regular Call Schedule:** Last Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
+  * **Call Notes and Group Documents:** [IIIF Newspapers Community Group Folder][newspapers-folder]
+  * **Regular Call Schedule:** Fourth Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
   * **Call Connection Information:** Connect Online at [https://bluejeans.com/753929435][https://bluejeans.com/753929435] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 753929435
 
 [newspapers-awesome-iiif]: https://github.com/IIIF/awesome-iiif#newspapers "Newspapers on Awesome-IIIF"


### PR DESCRIPTION
Made a few edits to the newspapers group page as part of the group page standardization effort - moved a few links up into the About section, added meeting schedule and call info to the Organization section - see http://newspapers_group.iiif.io/community/groups/newspapers/

Standby for +1 from kestlund and glen.robson...