### PR TITLE
added link to international numbers for av, museums, and devs groups

### DIFF
--- a/source/community/groups/av/index.md
+++ b/source/community/groups/av/index.md
@@ -15,7 +15,7 @@ The IIIF A/V Technical Specification Group aims to extend to A/V the benefits of
   * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# av IIIF Slack channel][av-slack] ([Join Slack][slack])
   * **Call Notes and Group Documents:** [IIIF A/V Tech Spec Group folder][av-folder]
   * **Regular Call Schedule:** Every other week (opposite the general IIIF Community Call) on Tuesdays at 12:00pm Eastern - see [IIIF Community Calendar][iiif-calendar] for details
-  * **Call Connection Information:** Connect Online at [https://bluejeans.com/608386174][https://bluejeans.com/608386174] or by Phone: +1.408.740.7256 (US)/ +1.888.240.2560 (US Toll Free)/ +1.408.317.9253 - Enter Meeting ID: 608386174
+  * **Call Connection Information:** Connect Online at [https://bluejeans.com/608386174][https://bluejeans.com/608386174] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 608386174
 
 [av-user-stories]: https://github.com/IIIF/iiif-av/issues "Audiovisual User Stories"
 [bl-workshop-2016-04]: https://goo.gl/iVXEFD "Use cases and notes from April 2015 workshop at British Library"
@@ -27,6 +27,7 @@ The IIIF A/V Technical Specification Group aims to extend to A/V the benefits of
 [slack]: http://bit.ly/iiif-slack
 [https://bluejeans.com/608386174]: https://bluejeans.com/608386174
 [iiif-calendar]: http://iiif.io/community/groups/
+[international-bluejeans]: https://bluejeans.com/numbers?ll=en
 
 
 {% include acronyms.md %}

--- a/source/community/groups/museums/index.md
+++ b/source/community/groups/museums/index.md
@@ -18,7 +18,7 @@ The IIIF Museums Community Group was formed in order to facilitate the discussio
   * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# museums IIIF Slack channel][museums-slack] ([Join Slack][slack])
   * **Call Notes and Group Documents:** [IIIF Museums Community Group folder][museums-folder]
   * **Regular Call Schedule:** First Tuesday of every month at 11:00am Eastern - see [IIIF Community Calendar][iiif-calendar] for details
-  * **Call Connection Information:** Connect Online at [https://bluejeans.com/390621048][https://bluejeans.com/390621048] or by Phone: +1.408.740.7256 (US)/ +1.888.240.2560 (US Toll Free)/ +1.408.317.9253 - Enter Meeting ID: 390621048
+  * **Call Connection Information:** Connect Online at [https://bluejeans.com/390621048][https://bluejeans.com/390621048] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 390621048
 
   [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss "IIIF-Discuss Forum"
   [museums-slack]: https://iiif.slack.com/messages/museums/details/
@@ -26,5 +26,6 @@ The IIIF Museums Community Group was formed in order to facilitate the discussio
   [slack]: http://bit.ly/iiif-slack
   [https://bluejeans.com/390621048]: https://bluejeans.com/390621048
   [iiif-calendar]: http://iiif.io/community/groups/
+  [international-bluejeans]: https://bluejeans.com/numbers?ll=en
 
 {% include acronyms.md %}

--- a/source/community/groups/software/index.md
+++ b/source/community/groups/software/index.md
@@ -24,7 +24,7 @@ To advance the growth and adoption of interoperable software with IIIF, the Soft
 * **Communication Channels:** Virtual meetings announced on [IIIF-Discuss][iiif-discuss]. General discussion on the [# softwaredevs IIIF Slack channel][devs-slack] ([Join Slack][join-slack])
 * **Call Notes and Group Documents:** [IIIF Software Developers Folder][devs-folder]
 * **Regular Meeting Schedule:** Every other week (opposite the general IIIF Community Call) on Wednesdays at 12:00pm Eastern - see [IIIF Community Calendar][calendar] for details
-* **Call Connection Information:** Connect online at [https://bluejeans.com/782319325][bluejeans] or by Phone: +1.408.740.7256 (US)/ +1.888.240.2560 (US Toll Free)/ +1.408.317.9253 - Enter Meeting ID: 782319325
+* **Call Connection Information:** Connect online at [https://bluejeans.com/782319325][bluejeans] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 782319325
 
 
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss
@@ -33,6 +33,7 @@ To advance the growth and adoption of interoperable software with IIIF, the Soft
 [devs-folder]: https://drive.google.com/drive/folders/0B8WLA_XCC1koZUF6TEFmQW5Vc0E?usp=sharing
 [calendar]: http://iiif.io/community/groups/
 [bluejeans]: https://bluejeans.com/782319325
+[international-bluejeans]: https://bluejeans.com/numbers?ll=en
 
 
 {% include acronyms.md %}


### PR DESCRIPTION
In updating the manuscripts and newspapers group pages I realized it's better to include 1 US number and then link to the international numbers like we do with community calls - so I went ahead and updated Av: http://international_call_info.iiif.io/community/groups/av/ , Museums: http://international_call_info.iiif.io/community/groups/museums/ , and Software devs: http://international_call_info.iiif.io/community/groups/software/

Once newspapers and manuscripts are merged, they will all have the same language in the call connection field. 