### PR TITLE
added names to call moderator rotation

### DIFF
--- a/scripts/call_calendar_generator.rb
+++ b/scripts/call_calendar_generator.rb
@@ -15,6 +15,7 @@ MODERATORS = {
     technical: [
       "Appleby",
       "Crane",
+      "Ronallo",
       "Sanderson",
       "Stroop",
       "Warner"
@@ -22,9 +23,15 @@ MODERATORS = {
     community: [
       "Albritton",
       "Cramer",
+      "Estlund",
+      "Matienzo",
       "McGrattan",
+      "Rabun",
+      "Robson",
+      "Shaw",
+      "Singhal",
       "Snydman",
-      "Rabun"
+      "Winget"
     ].uniq.sort!
 }
 


### PR DESCRIPTION
per community call guidelines, added additional CoCo members and group leaders to call moderator rotation script, with exception of those who opted out.

scripts/call_calendar_generator.rb