### PR TITLE
added univ of basel to consortium list

### DIFF
--- a/source/_data/institutions.yml
+++ b/source/_data/institutions.yml
@@ -146,6 +146,9 @@
 - name: University College Dublin
   uri:
   iiifc:
+- name: University of Basel, Digital Humanities Lab
+  uri: http://dhlab.unibas.ch/
+  iiifc: 2
 - name: University of Edinburgh
   uri: http://www.ed.ac.uk/
   iiifc: 2


### PR DESCRIPTION
University of Basel Digital Humanities Lab is joining the IIIF Consortium - added them to the list: http://univ_basel.iiif.io/community/consortium/#members

Closes #1022 