### PR TITLE
added better info for community calls

### DIFF
--- a/source/community/call/index.md
+++ b/source/community/call/index.md
@@ -1,0 +1,24 @@
+---
+title: "IIIF Community Calls"
+layout: spec
+tags: []
+cssversion: 2
+---
+
+The IIIF community calls alternate between a technical and community focus, providing a forum for new and existing participants to share their work, learn about activities across the community, and discuss IIIF technology and future directions. Anyone with an interest in IIIF may join the regularly scheduled calls.
+
+## Call Details
+
+  * **Regular Call Schedule:** Every other week on Wednesdays at 12:00pm Eastern - see [IIIF Community Calendar][iiif-calendar] for dates
+  * **Communication Channels:** Meeting agenda and reminders are announced on the [IIIF-Discuss][iiif-discuss] email list
+  * **Call Notes:** [Community Call Notes folder][comm-notes]
+  * **Call Connection Information:** Connect Online at [https://bluejeans.com/273449388][https://bluejeans.com/273449388] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 273449388
+
+  [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss "IIIF-Discuss Forum"
+  [comm-notes]: https://drive.google.com/drive/u/0/folders/0B9EeoRu2zWerNkktNVp5bDhleE0
+  [https://bluejeans.com/273449388]: https://bluejeans.com/273449388
+  [iiif-calendar]: http://iiif.io/community/groups/
+  [international-bluejeans]: https://bluejeans.com/numbers?ll=en
+
+
+{% include acronyms.md %}

--- a/source/community/index.html
+++ b/source/community/index.html
@@ -29,8 +29,10 @@ redirect_from:
             <div>Attend a IIIF Event:
                 <pre style="padding-left: 30px"><a href="http://iiif.io/event/">http://iiif.io/event/</a></pre></div>
 
-            <div>Participate in bi-weekly teleconferences. Call connection details are posted in the <a href="https://groups.google.com/forum/#!forum/iiif-discuss">iiif-discuss list</a>.</div>
-            <div><p>The schedule for IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</p></div>
+            <div>Participate in bi-weekly teleconferences:
+                <pre style="padding-left: 30px"><a href="http://iiif.io/community/call">http://iiif.io/community/call</a></pre></div>
+
+            <div><p>The schedule for all IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</p></div>
           </section>
 
           <section id="community-groups" class="quick-start wrapper">


### PR DESCRIPTION
To make it easier for people to join the community calls, I put all of the call info in one place (similar to the group call info). See: http://community_call_page.iiif.io/community/call/

closes #1032 