### PR TITLE
publishing vatican call for proposals

### DIFF
--- a/source/event/2017/vatican-cfp.md
+++ b/source/event/2017/vatican-cfp.md
@@ -1,0 +1,34 @@
+---
+title: "Call for Proposals: 2nd Annual IIIF Conference in The Vatican, June 6-9, 2017"
+layout: spec
+tags: [event ]
+---
+
+Proposals are now being accepted for presentations and sessions at the second annual [IIIF Conference in The Vatican][iiif-vatican], June 6-9, 2017. This year’s conference will include a day of plenary presentations, followed by two days of parallel sessions. We welcome your ideas!
+
+  * **[Submit a Proposal][cfp-form]**
+
+## Types of Proposals:
+**Wednesday, June 7 Plenary:**  
+
+  * Lightning Talks - Brief individual presentation related to IIIF (Note: we are considering also including a demo session as a follow-up for lightning talks, where presenters can show more of what they have been working on in an interactive social setting. When submitting a lightning talk proposal, please indicate if you would also be interested in structured time for stationed demos.)
+
+**Thursday and Friday, June 8-9 Parallel Sessions:**  
+
+  * Presentation Sessions - 30 minute session for individual or group presentations and discussion
+  * Discussion Sessions - 1-2 hour group discussion, working toward a shared goal
+  * On-boarding Workshops - 1-2 hour training sessions focused on new adopters and/or end users, with active teaching/learning environment and learning outcomes
+
+## Suggested Topics/Areas of focus:
+  * IIIF implementations
+  * Discovery of IIIF resources
+  * IIIF content communities (manuscripts, newspapers, archival content, etc.)
+  * IIIF and museums
+  * IIIF technical specifications
+  * IIIF-compatible software and experimentation
+  * Training materials and documentation
+
+The deadline for proposals is February 23, 2017. You will be notified of proposal acceptance no later than March 15, 2017. Please stay tuned for details about conference registration, and feel free to contact Sheila Rabun at srabun@iiif.io with any questions.
+
+[iiif-vatican]: http://iiif.io/event/2017/vatican/
+[cfp-form]: https://goo.gl/forms/IZRhbkTNZCEvOAm62

--- a/source/event/2017/vatican.md
+++ b/source/event/2017/vatican.md
@@ -12,7 +12,7 @@ tags: [event ]
 
 ## IIIF Conference - The Vatican - 2017
 
-The second annual International Image Interoperability Framework ([IIIF][home-page]) Conference in The Vatican is intended for a wide range of participants and interested parties across the IIIF community. See below for more details about the conference schedule.
+The second annual International Image Interoperability Framework ([IIIF][home-page]) Conference in The Vatican is intended for a wide range of participants and interested parties across the IIIF community. A [Call for Proposals][vatican-cfp] is now open until February 23, 2017.
 
 ### Logistics
 
@@ -35,8 +35,11 @@ The general conference schedule will be as follows:
 
 Stay tuned for more detailed schedule and capacity information.
 
+*Last updated January 23, 2017*
+
 
 [home-page]: http://iiif.io/
 [conduct]: /event/conduct/
 [institute]: http://www.patristicum.org/en/conference-center
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss
+[vatican-cfp]: /event/2017/vatican-cfp


### PR DESCRIPTION
Added CfP info to website: http://vatican_cfp.iiif.io/event/2017/vatican-cfp/, linked from http://vatican_cfp.iiif.io/event/2017/vatican/

