### PR TITLE
university of basel joins consortium announcement

### DIFF
--- a/source/_posts/2017-01-30-univ-basel-joins-iiifc.md
+++ b/source/_posts/2017-01-30-univ-basel-joins-iiifc.md
@@ -1,0 +1,21 @@
+---
+title: University of Basel Digital Humanities Lab Joins the IIIF Consortium
+author: Sheila Rabun
+date: 2017-01-30
+tags: [iiif-c, announcements]
+layout: post
+---
+
+The [Digital Humanities (DH) Lab of the University of Basel][dhlab-basel] is now the newest member of the [IIIF Consortium][iiif-c], bringing membership to a total of 40 institutions worldwide.
+
+Founded nearly 100 years ago, the University of Basel’s DH Lab has roots in scientific photography that continue to influence current work in developing new capturing systems and software for the imaging industry, and offering courses on color science, internet technologies, photography and digital permanence. Besides imaging technologies (including color science and perception), staff and students also focus on semantic web technologies and digital preservation in their research. Since 2014, the DH Lab has overseen operations of the [Data and Service Center for the Humanities][dsch], an RDF-based digital infrastructure for sustainable access to sources and research data in the humanities. One of the components of this infrastructure is [SPI][spi], an IIIF-compliant, high-performance image server with additional features for image modification.
+
+Representing the DH Lab and management team, Prof. Lukas Rosenthaler and Dr. Peter Fornaro have stated, “We are looking forward to collaborating with the IIIF Consortium on the development of simplified, standardised data structures to facilitate interoperability and digital preservation.”
+
+Welcome, and congratulations to the University of Basel Digital Humanities Lab!
+
+
+[dhlab-basel]: http://dhlab.unibas.ch/
+[iiif-c]: /community/consortium/
+[dsch]: http://dh-center.ch/
+[spi]: https://github.com/dhlab-basel/Sipi


### PR DESCRIPTION
News announcement for new consortium member: http://basel_news.iiif.io/news/2017/01/30/univ-basel-joins-iiifc/ closes #1023 