### PR TITLE
Correct copyright start date to 2015

### DIFF
--- a/source/api/auth/0.9/index.md
+++ b/source/api/auth/0.9/index.md
@@ -33,7 +33,7 @@ This is a work in progress. We are actively seeking implementations and feedback
   * **[Simeon Warner](https://orcid.org/0000-0002-7970-7855)** [![ORCID iD](/img/orcid_16x16.png)](https://orcid.org/0000-0002-7970-7855), [_Cornell University_](https://www.cornell.edu/)
   {: .names}
 
-{% include copyright.md %}
+{% include copyright2015.md %}
 
 ----
 

--- a/source/api/auth/1.0/index.md
+++ b/source/api/auth/1.0/index.md
@@ -32,7 +32,7 @@ __Previous Version:__ [0.9.4][prev-version]
   * **[Simeon Warner](https://orcid.org/0000-0002-7970-7855)** [![ORCID iD](/img/orcid_16x16.png)](https://orcid.org/0000-0002-7970-7855), [_Cornell University_](https://www.cornell.edu/)
   {: .names}
 
-{% include copyright.md %}
+{% include copyright2015.md %}
 
 ----
 

--- a/source/api/search/0.9/index.md
+++ b/source/api/search/0.9/index.md
@@ -29,7 +29,7 @@ __Latest Stable Version:__ [{{ site.search_api.latest.major }}.{{ site.search_ap
   * **[Simeon Warner](https://orcid.org/0000-0002-7970-7855)** [![ORCID iD](/img/orcid_16x16.png)](https://orcid.org/0000-0002-7970-7855), [_Cornell University_](https://www.cornell.edu/)
   {: .names}
 
-{% include copyright.md %}
+{% include copyright2015.md %}
 
 ## Table of Contents
 {:.no_toc}

--- a/source/api/search/1.0/index.md
+++ b/source/api/search/1.0/index.md
@@ -29,7 +29,7 @@ __Latest Stable Version:__ [{{ site.search_api.latest.major }}.{{ site.search_ap
   * **[Simeon Warner](https://orcid.org/0000-0002-7970-7855)** [![ORCID iD](/img/orcid_16x16.png)](https://orcid.org/0000-0002-7970-7855), [_Cornell University_](https://www.cornell.edu/)
   {: .names}
 
-{% include copyright.md %}
+{% include copyright2015.md %}
 
 ----
 


### PR DESCRIPTION
FIrst drafts of search and auth APIs were published in 2015 and so that should be start of year range in copyright statement. (Looks silly to say 2012-2017 to me, and misleading)