### PR TITLE
added sponsorship info and a few updates

### DIFF
--- a/source/event/2017/vatican-cfp.md
+++ b/source/event/2017/vatican-cfp.md
@@ -1,5 +1,5 @@
 ---
-title: "Call for Proposals: 2nd Annual IIIF Conference in The Vatican, June 6-9, 2017"
+title: "Call for Proposals: 2017 IIIF Conference in The Vatican"
 layout: spec
 tags: [event ]
 ---

--- a/source/event/2017/vatican-sponsors.md
+++ b/source/event/2017/vatican-sponsors.md
@@ -1,0 +1,39 @@
+---
+title: "Call for Sponsors: 2017 IIIF Conference in The Vatican"
+layout: spec
+tags: [event ]
+---
+
+The International Image Interoperability Framework (IIIF) conference offers an excellent opportunity for vendors to promote products and services and interact with participants from all over the world. The [2017 IIIF Conference][iiif-vatican] will take place at the Institutum Patristicum Augustinianum in the Vatican, June 6-9, 2017.
+
+## Sponsorship Levels and Benefits
+
+**Silver - $1,000**  
+
+  * Opportunity to distribute literature at registration table(s)
+  * Acknowledgement by name on iiif.io website and event registration form
+  * Acknowledgement by name on June 6 plenary program
+  * Acknowledgment in June 6 & 7 plenary welcome presentations
+  * Option to present a lightning talk during June 7 plenary
+  * 1 conference registration
+
+**Gold - $2,500**  
+
+  * All of the Silver benefits listed above, plus:
+  * Logo on iiif.io website and event registration form
+  * Logo on June 6 plenary program
+  * Option for designated classroom space during June 7 & 8 parallel sessions
+  * Informational table and/or poster in common space
+  * 1 additional conference registration (2 total)
+
+**Platinum - $5,000**
+
+  * All of the Silver and Gold benefits listed above, plus
+  * Welcome speech at June 6 reception
+  * 1 additional conference registration (3 total)
+
+## Contact and Logistics
+
+To indicate your interest in sponsorship, please contact Sheila Rabun, IIIF Community and Communications Officer, at srabun@iiif.io by March 15, 2017, to guarantee your spot in the lightning talk program and/or parallel sessions. Payments will be accepted via check or wire transfer to the Council on Library and Information Services (CLIR), administrative home of the IIIF Consortium. Please note that sponsorship will not be confirmed until payment is received.
+
+[iiif-vatican]: http://iiif.io/event/2017/vatican/

--- a/source/event/2017/vatican.md
+++ b/source/event/2017/vatican.md
@@ -1,5 +1,5 @@
 ---
-title: "2nd Annual IIIF Conference - The Vatican - 2017"
+title: "2017 IIIF Conference - The Vatican"
 layout: spec
 tags: [event ]
 ---
@@ -12,7 +12,12 @@ tags: [event ]
 
 ## IIIF Conference - The Vatican - 2017
 
-The second annual International Image Interoperability Framework ([IIIF][home-page]) Conference in The Vatican is intended for a wide range of participants and interested parties across the IIIF community. A [Call for Proposals][vatican-cfp] is now open until February 23, 2017.
+The second annual International Image Interoperability Framework ([IIIF][home-page]) Conference in The Vatican is intended for a wide range of participants and interested parties across the IIIF community. The conference will consist of two events with separate capacity and registration:
+
+1. IIIF Showcase: Unlocking the World's Digital Images, an outreach event on Tuesday, June 6, intended for interested parties who are new to IIIF and want to quickly get up to speed and understand the community and its benefits.
+2. IIIF Conference Program, June 7-9, including plenary presentations and parallel sessions for content curators, repository managers, software developers, and researchers from across the IIIF community.
+
+A [Call for Proposals][vatican-cfp] is now open until February 23, 2017. A [Call for Sponsors][vatican-sponsors] is open with an initial deadline of March 15, 2017.
 
 ### Logistics
 
@@ -28,14 +33,14 @@ The second annual International Image Interoperability Framework ([IIIF][home-pa
 
 The general conference schedule will be as follows:
 
-* Tuesday, June 6: IIIF Conference Plenary - Outreach Event
+* Tuesday, June 6: IIIF Showcase: Unlocking the World's Digital Images
 * Wednesday, June 7: IIIF Conference Plenary
 * Thursday, June 8: IIIF Conference Parallel Tracks
 * Friday, June 9: IIIF Conference Parallel Tracks
 
 Stay tuned for more detailed schedule and capacity information.
 
-*Last updated January 23, 2017*
+*Last updated February 8, 2017*
 
 
 [home-page]: http://iiif.io/
@@ -43,3 +48,4 @@ Stay tuned for more detailed schedule and capacity information.
 [institute]: http://www.patristicum.org/en/conference-center
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss
 [vatican-cfp]: /event/2017/vatican-cfp
+[vatican-sponsors]: /event/2017/vatican-sponsors


### PR DESCRIPTION
Added info about Sponsorship: http://vatican_sponsors.iiif.io/event/2017/vatican-sponsors/

Updated from"2nd annual..." to "2017 IIIF Conference" on other event pages: http://vatican_sponsors.iiif.io/event/2017/vatican/ and http://vatican_sponsors.iiif.io/event/2017/vatican-cfp/

Added clarification on 2 separate events, and Call for Sponsors link on main event page: http://vatican_sponsors.iiif.io/event/2017/vatican/