### PR TITLE
adding two blog posts from Brumfield labs re commissioned implementat…

### DIFF
--- a/source/_posts/2017-02-17-from-the-page.md
+++ b/source/_posts/2017-02-17-from-the-page.md
@@ -2,7 +2,7 @@
 title: Full IIIF Support for Collaborative Digital Editions in FromThePage
 author: Ben Brumfield and Sara Carlstead Brumfield, Brumfield Labs
 date: 2017-02-17
-tags: [announcements]
+tags: [announcements ]
 layout: post
 ---
 

--- a/source/_posts/2017-02-17-from-the-page.md
+++ b/source/_posts/2017-02-17-from-the-page.md
@@ -1,0 +1,21 @@
+---
+title: Full IIIF Support for Collaborative Digital Editions in FromThePage
+author: Ben Brumfield and Sara Carlstead Brumfield, Brumfield Labs
+date: 2017-02-17
+tags: [announcements]
+layout: post
+---
+
+Thanks to a commissioned implementation grant, Brumfield Labs has implemented full client-side and server-side support for IIIF in the collaborative digital edition tool FromThePage. IIIF support allows editors to focus on textual issues instead of image format challenges, whether they run public-facing crowdsourced transcription projects or scholarly translation projects within small research groups.
+
+Using FromThePage’s IIIF client functionality, editorial projects can build transcription, translation, and indexing projects on documents from any IIIF repository, importing manifests directly into the collaborative platform. This eliminates the need for editors to upload zip files or PDFs, valuable not only because it reduces tedium, but also because it allows editors to work with material that cannot be released in high-resolution images but can be served as tiles through the [IIIF Image API][iiif-image].
+
+For projects whose images have been uploaded directly to FromThePage, whether bulk uploads of zip files or images uploaded directly from mobile devices in the field, IIIF server functionality allows reuse within the ecosystem of IIIF scholarly tools. Both the Image API and the [IIIF Presentation API][iiif-prezi] allow other clients like the Universal Viewer or Mirador to display FromThePage documents for presentation and annotation. Transcriptions, translations, and comments created within FromThePage are exposed as AnnotationLists and Layers, so there is no need for additional exports for scholarly reuse.
+
+FromThePage is an open source tool supported by Brumfield Labs, and can be downloaded at [https://github.com/benwbrum/fromthepage][fromthepage]. Hosted FromThePage accounts are available at [FromThePage.com][fromthepage.com]. A demo video is available at [https://www.youtube.com/watch?v=92Blut3l2ds][demo]
+
+[iiif-image]: /api/image/
+[iiif-prezi]: /api/presentation/
+[fromthepage]: https://github.com/benwbrum/fromthepage
+[fromthepage.com]: http://fromthepage.com/
+[demo]: https://www.youtube.com/watch?v=92Blut3l2ds

--- a/source/_posts/2017-02-17-pontiiif.md
+++ b/source/_posts/2017-02-17-pontiiif.md
@@ -1,0 +1,27 @@
+---
+title: IIIF Discovery with Pontiiif
+author: Sara Carlstead Brumfield and Ben Brumfield, Brumfield Labs
+date: 2017-02-17
+tags: [announcements]
+layout: post
+---
+
+Interoperable image resources are only useful if they can be discovered. While the [IIIF Content Search API][iiif-search] "search within" for IIIF annotations is well defined and individual institutions have search technologies for their content, there has been no way to search for IIIF-enabled content across institutions.
+
+To address this challenge, Brumfield Labs proposed & built Pontiiif, a cross repository search engine for IIIF manifests, as a commissioned implementation. Pontiiif crawls and indexes IIIF manifests starting at top-level collection manifests. It ingests labels, descriptions, navDates, licenses and metadata from collections and manifests, storing them in an ElasticSearch datastore. As collections are crawled, any errors are logged into files which can be downloaded from Pontiiif, providing a way to validate a content provider’s implementation of the Presentation API.
+
+Pontiiif also includes a web UI that allows simple search across all indexed fields, or advanced search on specific fields. Search results allow users to drag and drop IIIF icons onto Mirador, open manifests within the Universal Viewer, or view the manifest JSON directly.
+
+Pontiiif includes a simple draft API -- for example, [http://pontiiif.brumfieldlabs.com/api/v0.0/search/Virginia][example] will return the results of the search as a IIIF Collection manifest for ingestion by other IIIF clients.
+
+The Pontiiif 1.1 release incorporates feedback from the IIIF community, regularizing the mechanism for crawling collections. When a user adds a collection to crawl, this collection is stored in a list of crawlable collections in addition to initiating an immediate crawl of the added collection. Each indexed collection is displayed on the “add collection” screen, along with the most recent dates at which it was indexed.
+
+You can search with Pontiiif at [http://pontiiif.brumfieldlabs.com/][search-pontiiif]
+The source code is available at [https://github.com/saracarl/Pontiiif][code]
+A preview demo is available at [https://www.youtube.com/watch?v=v2-3hAtidUM][demo]
+
+[iiif-search]: /api/search/
+[example]: http://pontiiif.brumfieldlabs.com/api/v0.0/search/Virginia
+[search-pontiiif]: http://pontiiif.brumfieldlabs.com/
+[code]: https://github.com/saracarl/Pontiiif
+[demo]: https://www.youtube.com/watch?v=v2-3hAtidUM

--- a/source/_posts/2017-02-17-pontiiif.md
+++ b/source/_posts/2017-02-17-pontiiif.md
@@ -2,7 +2,7 @@
 title: IIIF Discovery with Pontiiif
 author: Sara Carlstead Brumfield and Ben Brumfield, Brumfield Labs
 date: 2017-02-17
-tags: [announcements]
+tags: [announcements ]
 layout: post
 ---
 


### PR DESCRIPTION
…ions

closes #1076 

`cap production deploy` failed due to no space left on device:

`(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as iiif@54.201.19.22: git exit status: 1
git stdout: Fetching origin
git stderr: error: file write error (No space left on device)
fatal: unable to write sha1 file
fatal: unpack-objects failed
error: Could not fetch origin

SSHKit::Command::Failed: git exit status: 1
git stdout: Fetching origin
git stderr: error: file write error (No space left on device)
fatal: unable to write sha1 file
fatal: unpack-objects failed
error: Could not fetch origin

Tasks: TOP => git:create_release => git:update
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as iiif@54.201.19.22: git exit status: 1
git stdout: Fetching origin
git stderr: error: file write error (No space left on device)
fatal: unable to write sha1 file
fatal: unpack-objects failed
error: Could not fetch origin`