### PR TITLE
added Monday Mirador and UV meetings

### DIFF
--- a/source/event/2017/vatican.md
+++ b/source/event/2017/vatican.md
@@ -4,7 +4,13 @@ layout: spec
 tags: [event ]
 ---
 
-The International Image Interoperability Framework ([IIIF][home-page]) 2017 Conference in The Vatican is intended for a wide range of participants and interested parties, including digital image repository managers, content curators, software developers, scholars, and administrators at libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. The conference will consist of two events with separate registration: a [IIIF Showcase event][showcase-reg] on Tuesday, June 6, followed by a [3-day conference June 7-9][conference-reg].
+The International Image Interoperability Framework ([IIIF][home-page]) 2017 Conference in The Vatican is intended for a wide range of participants and interested parties, including digital image repository managers, content curators, software developers, scholars, and administrators at libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. The conference will consist of two events with separate registration: a [IIIF Showcase event][showcase-reg] on Tuesday, June 6, followed by a [3-day conference June 7-9][conference-reg]. The [Mirador Viewer][mirador] and [Universal Viewer][uv] group meetings will take place on Monday, June 5, prior to the Showcase event and conference.
+
+## Mirador and Universal Viewer Meetings
+
+* Dates: June 5, 2017
+* Registration: No registration necessary - to RSVP, please indicate your plans to attend the Monday meetings via the [Showcase registration form][showcase-reg] and/or the [Conference registration form][conference-reg].
+* Location: [Institutum Patristicum Augustinianum][institute] (Augustinian Patristic Institute Conference Center)
 
 ## IIIF Showcase: Unlocking the World's Digital Images
 The IIIF Showcase is intended for all interested parties who are new to IIIF and want to quickly get up to speed and understand the community, technology, and benefits of IIIF.
@@ -15,29 +21,30 @@ The IIIF Showcase is intended for all interested parties who are new to IIIF and
 * Capacity: 400 participants
 
 ## 2017 IIIF Conference
-The Conference will include lightning talks, presentations, workshops, and discussion sessions for content curators, repository managers, software developers, administrators, and researchers from across the IIIF community. Topics of interest include: IIIF implementations, Discovery of IIIF resources, Content communities (manuscripts, newspapers, archival content, etc.), IIIF and museums, Technical specifications, IIIF-compatible software and experimentation, and On-boarding, training materials, and documentation.
+The Conference will include lightning talks, presentations, workshops, and discussion sessions for content curators, repository managers, software developers, administrators, and researchers from across the IIIF community. Topics of interest include: IIIF implementations, Discovery of IIIF resources, Content communities (manuscripts, newspapers, archival content, etc.), IIIF and museums, Technical specifications, IIIF-compatible software and experimentation, and On-boarding, training materials, and documentation. Meetings for Universal Viewer and Mirador will take place on Monday, June 5 - see schedule section below.
 
 * Dates: June 7-9, 2017
 * Registration: [https://iiif-conference-vatican2017.eventbrite.com][conference-reg]
 * Location: [Institutum Patristicum Augustinianum][institute] (Augustinian Patristic Institute Conference Center)
 * Capacity: 200 participants
 
-A [Call for Proposals][vatican-cfp] is now open until February 23, 2017. A [Call for Sponsors][vatican-sponsors] is now open with an initial deadline of March 15, 2017.
+A [Call for Sponsors][vatican-sponsors] is now open with an initial deadline of March 15, 2017.
 
 ## Schedule
 
 The general schedule will be as follows:
 
-* Tuesday, June 6: IIIF Showcase: Unlocking the World's Digital Images
-* Wednesday, June 7: IIIF Conference Plenary
-* Thursday, June 8: IIIF Conference Parallel Tracks
-* Friday, June 9: IIIF Conference Parallel Tracks
+* Monday, June 5: Mirador group meeting (9:30am-12:30pm) and Universal Viewer group meeting (2pm-5pm), no registration necessary - to RSVP, please indicate your plans to attend via the [Showcase registration form][showcase-reg] and/or the [Conference registration form][conference-reg].
+* Tuesday, June 6: [IIIF Showcase: Unlocking the World's Digital Images][showcase-reg]
+* Wednesday, June 7: [IIIF Conference Plenary][conference-reg]
+* Thursday, June 8: [IIIF Conference Parallel Tracks][conference-reg]
+* Friday, June 9: [IIIF Conference Parallel Tracks][conference-reg]
 
 Stay tuned for more detailed schedule information.
 
 The IIIF [Code of Conduct][conduct] applies to all IIIF events and related activities. Please direct any questions to Sheila Rabun, IIIF Community and Communications Officer, at srabun@iiif.io.
 
-*Last updated February 20, 2017*
+*Last updated February 27, 2017*
 
 
 [home-page]: http://iiif.io/
@@ -48,3 +55,5 @@ The IIIF [Code of Conduct][conduct] applies to all IIIF events and related activ
 [vatican-sponsors]: /event/2017/vatican-sponsors
 [showcase-reg]: https://iiif-showcase-vatican2017.eventbrite.com
 [conference-reg]: https://iiif-conference-vatican2017.eventbrite.com
+[mirador]: http://projectmirador.org
+[uv]: https://digirati.com/technology/our-solutions/universal-viewer/

--- a/source/index.html
+++ b/source/index.html
@@ -18,7 +18,7 @@ layout: default
           </header>
           <section class="front-announcement">
             <div>
-                <a href="/news/2017/01/19/auth-1-0-released/">Authentication API Version 1.0 Released</a>, 19 January 2017.
+                <a href="/event/2017/vatican">Register Now for the 2017 IIIF Conference, June 5-9, The Vatican</a>, 27 February 2017.
             </div>
           </section>
 


### PR DESCRIPTION
Mirador and UV meetings will be Monday June 5 prior to Showcase and Conference. I added this information to the event page: http://monday_vatican.iiif.io/event/2017/vatican/

I also updated homepage news item to highlight conference registration: http://monday_vatican.iiif.io/

