### PR TITLE
added clarification in tsg formation and approval section

### DIFF
--- a/source/community/groups/framework.md
+++ b/source/community/groups/framework.md
@@ -77,7 +77,7 @@ Technical Specification Groups are the main working vehicle for adding new APIs 
 
 ### Technical Specification Group Formation and Approval
 
-  * Technical Specification Groups should emerge naturally from discussions and needs within the community.
+  * Technical Specification Groups should emerge naturally from discussions and needs within the community, brought to attention on the [IIIF-Discuss email list][iiif-discuss].
   * Participants in discussions that show promise of inter-institutional convergence on common models or methods should document the shared needs and requirements in a Google document, resulting in a common understanding of:
     1. The overall domain into which the work will fall
     2. The shared needs and requirements within that domain
@@ -93,7 +93,8 @@ Technical Specification Groups are the main working vehicle for adding new APIs 
     * If fewer than three institutions are willing to contribute, then the group's topic is likely too specific and the work should be done outside of the Technical Specification Group process.  If more than three institutions object to the work being done, then there is a significant issue that should be resolved before committing resources.
     * For Technical Specification Groups where deliverables would involve additions or changes to existing technical specifications, at least two current members of the editorial board must sign up as members of the group to ensure consistency with existing and ongoing work.
   * At least two calendar weeks must pass between the CfP and official approval of the group.  If only one or two institutions are interested after four calendar weeks, then the CfP is considered closed and the original proposers of the charter should lead continued discussion and modify the charter before re-announcing.
-  * Once officially approved, Technical Specification Groups should be documented on the iiif.io website, noting the following information:
+  * Once officially approved, the Community and Communications Officer will schedule, announce, and facilitate an initial planning call for the group. During the first call, the group will determine willingness and availability of volunteers to chair the group, agree upon group chairs, and determine a regular call schedule for moving forward.
+  * Technical Specification Groups should be documented on the iiif.io website, noting the following information:
     1. Statement of the group focus and/or goals, and how the group came to be formed
     2. Link to the group charter
     3. Chair(s) of the group

--- a/source/community/groups/framework.md
+++ b/source/community/groups/framework.md
@@ -77,7 +77,7 @@ Technical Specification Groups are the main working vehicle for adding new APIs 
 
 ### Technical Specification Group Formation and Approval
 
-  * Technical Specification Groups should emerge naturally from discussions and needs within the community, brought to attention on the [IIIF-Discuss email list][iiif-discuss].
+  * Technical Specification Groups should emerge naturally from discussions and needs within the community, as discussed on the [IIIF-discuss mailing list][iiif-discuss]. If the discussion happens offline or in a smaller group, then summaries must be posted to solicit the input of the wider community.
   * Participants in discussions that show promise of inter-institutional convergence on common models or methods should document the shared needs and requirements in a Google document, resulting in a common understanding of:
     1. The overall domain into which the work will fall
     2. The shared needs and requirements within that domain


### PR DESCRIPTION
Updated Group Framework page to clarify TSG discussions and TSG process for choosing group chairs, scheduling meetings, per: https://docs.google.com/document/d/1E1u82AiEbEfSqyrRvdMMywcbJSrWifZY7SPzaM5zigg/edit#

See: http://group_doc_update.iiif.io/community/groups/framework/#technical-specification-group-formation-and-approval