### PR TITLE
minor updates to group pages

### DIFF
--- a/source/community/groups/av/index.md
+++ b/source/community/groups/av/index.md
@@ -15,18 +15,25 @@ The [IIIF A/V charter][av-charter] provides an outline and timeline for anticipa
 
 ## Organization
 
-  * **Chairs:**
-    * Tom Crane (Digirati)
-    * Jon Dunn (Indiana University)
-  * **Communication Channels:**
-    * Calls every other week on Tuesdays at 12:00pm Eastern (opposite the general IIIF Community Call) - see [IIIF Community Calendar][iiif-calendar] for details
-    * Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list.
-    * General discussion on the [# av IIIF Slack channel][av-slack] ([Join Slack][slack])
-  * **Call Notes and Group Documents:**
-    * [IIIF A/V Tech Spec Group folder][av-folder]
-  * **Call Connection Information:**
-    * Online: [https://bluejeans.com/222002812][https://bluejeans.com/222002812]
-    * Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 222002812
+**Chairs:**
+
+  * Tom Crane (Digirati)
+  * Jon Dunn (Indiana University)
+
+**Communication Channels:**
+
+  * Calls every other week on Tuesdays at 12:00pm Eastern (opposite the general IIIF Community Call) - see [IIIF Community Calendar][iiif-calendar] for details
+  * Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list
+  * General discussion on the [# av IIIF Slack channel][av-slack] ([Join Slack][slack])
+
+**Call Notes and Group Documents:**
+
+  * [IIIF A/V Tech Spec Group folder][av-folder]
+
+**Call Connection Information:**
+
+  * Online: [https://bluejeans.com/222002812][https://bluejeans.com/222002812]
+  * Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 222002812
 
 [av-user-stories]: https://github.com/IIIF/iiif-av/issues "Audiovisual User Stories"
 [bl-workshop-2016-04]: https://goo.gl/iVXEFD "Use cases and notes from April 2015 workshop at British Library"

--- a/source/community/groups/discovery/index.md
+++ b/source/community/groups/discovery/index.md
@@ -18,12 +18,13 @@ If successful, the work will enable the collaborative development of global or t
 **Chairs:**
 
   * Antoine Isaac (Europeana)
+  * Matt McGrattan (Digirati)
   * Robert Sanderson (The J. Paul Getty Trust)
 
 **Communication Channels:**
 
   * Calls very other week on Wednesdays at 1:00pm Eastern (opposite the general IIIF Community Call) - see [IIIF Community Calendar][iiif-calendar] for details
-  * Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list.
+  * Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list
   * General discussion on the [# discovery IIIF Slack channel][discovery-slack] ([Join Slack][slack])
 
 **Call Notes and Group Documents:**

--- a/source/community/groups/manuscripts/index.md
+++ b/source/community/groups/manuscripts/index.md
@@ -21,11 +21,26 @@ The IIIF MSS Group seeks to advance aims of the [IIIF­C][iiifc], which are to r
 
 ## Organization
 
-  * **Chair:** Ben Albritton (Stanford)
-  * **Communication Channels:** Virtual meetings announced on the [IIIF-Manuscripts][iiif-manuscripts] and [IIIF-Discuss][iiif-discuss] email lists. General discussion on the [# manuscripts IIIF Slack channel][manuscripts-slack] ([Join Slack][join-slack])
-  * **Call Notes and Group Documents:** [IIIF Manuscripts Community Group Folder][manuscripts-folder]
-  * **Regular Call Schedule:** Second Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
-  * **Call Connection Information:** Connect Online at [https://bluejeans.com/153288361][https://bluejeans.com/153288361] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 153288361
+**Chairs:**
+
+  * Benjamin Albritton (Stanford University)
+  * Rachel Di Cresce (University of Toronto)
+  * Jeffrey Witt (Loyola University Maryland)
+
+**Communication Channels:**
+
+  * Calls on the second Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
+  * Virtual meetings announced on the [IIIF-Manuscripts][iiif-manuscripts] and [IIIF-Discuss][iiif-discuss] email lists.
+  * General discussion on the [# manuscripts IIIF Slack channel][manuscripts-slack] ([Join Slack][join-slack])
+
+**Call Notes and Group Documents:**
+
+  * [IIIF Manuscripts Community Group Folder][manuscripts-folder]
+
+**Call Connection Information:**
+
+  * Online: [https://bluejeans.com/153288361][https://bluejeans.com/153288361]
+  * Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 153288361
 
 [ghent]: /event/2015/ghent/ "IIIF: Access to the World's Images - Ghent 2015"
 [iiifc]: /community/consortium/ "IIIF Consortium"

--- a/source/community/groups/museums/index.md
+++ b/source/community/groups/museums/index.md
@@ -14,11 +14,26 @@ The IIIF Museums Community Group was formed in order to facilitate the discussio
 
 ## Organization
 
-  * **Chairs:** Mike Appleby (Yale), Emmanuelle Delmas-Glass (Yale), and Tina Shah (Art Institute of Chicago)
-  * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# museums IIIF Slack channel][museums-slack] ([Join Slack][slack])
-  * **Call Notes and Group Documents:** [IIIF Museums Community Group folder][museums-folder]
-  * **Regular Call Schedule:** First Tuesday of every month at 11:00am Eastern - see [IIIF Community Calendar][iiif-calendar] for details
-  * **Call Connection Information:** Connect Online at [https://bluejeans.com/100103152][https://bluejeans.com/100103152] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 100103152
+**Chairs:**
+
+  * Mike Appleby (Yale)
+  * Emmanuelle Delmas-Glass (Yale)
+  * Tina Shah (Art Institute of Chicago)
+
+**Communication Channels:**
+
+  * Calls on the first Tuesday of every month at 11:00am Eastern - see [IIIF Community Calendar][iiif-calendar] for details
+  * Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list
+  * General discussion on the [# museums IIIF Slack channel][museums-slack] ([Join Slack][slack])
+
+**Call Notes and Group Documents:**
+
+  * [IIIF Museums Community Group folder][museums-folder]
+
+**Call Connection Information:**
+
+  * Online: [https://bluejeans.com/100103152][https://bluejeans.com/100103152]
+  * Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 100103152
 
   [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss "IIIF-Discuss Forum"
   [museums-slack]: https://iiif.slack.com/messages/museums/details/

--- a/source/community/groups/newspapers/index.md
+++ b/source/community/groups/newspapers/index.md
@@ -19,11 +19,25 @@ The IIIF Newspapers Community Group welcomes participants with an interest in im
 
 ## Organization
 
-  * **Chairs:** Karen Estlund (Pennsylvania State University) and Glen Robson (National Library of Wales)
-  * **Communication Channels:** Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list. General discussion on the [# newspapers IIIF Slack channel][newspapers-slack] ([Join Slack][join-slack])
-  * **Call Notes and Group Documents:** [IIIF Newspapers Community Group Folder][newspapers-folder]
-  * **Regular Call Schedule:** Fourth Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
-  * **Call Connection Information:** Connect Online at [https://bluejeans.com/753929435][https://bluejeans.com/753929435] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 753929435
+**Chairs:**
+
+  * Karen Estlund (Pennsylvania State University)
+  * Glen Robson (National Library of Wales)
+
+**Communication Channels:**
+
+  * Calls on the fourth Wednesday of every month at 11am Eastern - see [IIIF Community Calendar][calendar] for details
+  * Virtual meetings announced on the [IIIF-Discuss][iiif-discuss] email list
+  * General discussion on the [# newspapers IIIF Slack channel][newspapers-slack] ([Join Slack][join-slack])
+
+**Call Notes and Group Documents:**
+
+  * [IIIF Newspapers Community Group Folder][newspapers-folder]
+
+**Call Connection Information:**
+
+  * Online: [https://bluejeans.com/753929435][https://bluejeans.com/753929435]
+  * Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 753929435
 
 [newspapers-awesome-iiif]: https://github.com/IIIF/awesome-iiif#newspapers "Newspapers on Awesome-IIIF"
 [events]: /event "IIIF Events"

--- a/source/community/groups/software/index.md
+++ b/source/community/groups/software/index.md
@@ -20,11 +20,26 @@ To advance the growth and adoption of interoperable software with IIIF, the Soft
 * Develop opportunities and development practices for sustainable collaboration efforts across institutions and funding resources.
 
 ## Organization
-* **Chairs:** Rashmi Singhal (Harvard University) and Drew Winget (Stanford University)
-* **Communication Channels:** Virtual meetings announced on [IIIF-Discuss][iiif-discuss]. General discussion on the [# softwaredevs IIIF Slack channel][devs-slack] ([Join Slack][join-slack])
-* **Call Notes and Group Documents:** [IIIF Software Developers Folder][devs-folder]
-* **Regular Meeting Schedule:** Every other week (opposite the general IIIF Community Call) on Wednesdays at 12:00pm Eastern - see [IIIF Community Calendar][calendar] for details
-* **Call Connection Information:** Connect online at [https://bluejeans.com/782319325][bluejeans] or by Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 782319325
+
+**Chairs:**
+
+  * Rashmi Singhal (Harvard University)
+  * Drew Winget (Stanford University)
+
+**Communication Channels:**
+
+  * Calls every other week on Wednesdays at 12:00pm Eastern (opposite the general IIIF Community Call)  - see [IIIF Community Calendar][calendar] for details
+  * Virtual meetings announced on [IIIF-Discuss][iiif-discuss]
+  * General discussion on the [# softwaredevs IIIF Slack channel][devs-slack] ([Join Slack][join-slack])
+
+**Call Notes and Group Documents:**
+
+  * [IIIF Software Developers Folder][devs-folder]
+
+**Call Connection Information:**
+
+  * Online: [https://bluejeans.com/782319325][bluejeans]
+  * Phone: +1.888.240.2560 (US Toll Free) or see [international numbers][international-bluejeans] - Enter Meeting ID: 782319325
 
 
 [iiif-discuss]: https://groups.google.com/forum/#!forum/iiif-discuss


### PR DESCRIPTION
Added additional chairs to Discovery (Matt) and Manuscripts (Rachel and Jeff). Standardized Organization "sub-bullet" layout across groups.

AV: http://groups_updates.iiif.io/community/groups/av/
Discovery: http://groups_updates.iiif.io/community/groups/discovery/
Manuscripts: http://groups_updates.iiif.io/community/groups/manuscripts/
Museums: http://groups_updates.iiif.io/community/groups/museums/
Newspapers: http://groups_updates.iiif.io/community/groups/newspapers/
Software Devs: http://groups_updates.iiif.io/community/groups/software/