### PR TITLE
link to sched, other updates

### DIFF
--- a/source/event/2017/vatican.md
+++ b/source/event/2017/vatican.md
@@ -4,27 +4,24 @@ layout: spec
 tags: [event ]
 ---
 
+## Overview
+
 The International Image Interoperability Framework ([IIIF][home-page]) 2017 Conference in The Vatican is intended for a wide range of participants and interested parties, including digital image repository managers, content curators, software developers, scholars, and administrators at libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. The conference will consist of two events with separate registration: a [IIIF Showcase event][showcase-reg] on Tuesday, June 6, followed by a [3-day conference June 7-9][conference-reg]. The pre-conference [Mirador Viewer][mirador] and [Universal Viewer][uv] group meetings will take place on Monday, June 5, prior to the Showcase event and conference.
 
-A [Call for Sponsors][vatican-sponsors] is now open with an initial deadline of March 15, 2017.
+Schedule details are available via [Sched][conf-sched]. The general schedule will be as follows:
 
-## Schedule
-
-The general schedule will be as follows:
-
-* Monday, June 5: Pre-conference Mirador group meeting (9:30am-12:30pm) and Universal Viewer group meeting (2pm-5pm), no registration necessary - to RSVP, please indicate your plans to attend via the [Showcase registration form][showcase-reg] and/or the [Conference registration form][conference-reg].
+* Monday, June 5: Pre-conference meetings: Mirador and Universal Viewer
 * **Tuesday, June 6: [IIIF Showcase: Unlocking the World's Digital Images][showcase-reg]**
 * Wednesday, June 7: [IIIF Conference][conference-reg] Plenary Day
 * Thursday, June 8: [IIIF Conference][conference-reg] Parallel Tracks
 * Friday, June 9: [IIIF Conference][conference-reg] Parallel Tracks
-
-Stay tuned for more detailed schedule information.
 
 ## Pre-Conference Meetings: Mirador and Universal Viewer
 
 * Dates: June 5, 2017
 * Registration: No registration necessary - to RSVP, please indicate your plans to attend the Monday meetings via the [Showcase registration form][showcase-reg] and/or the [Conference registration form][conference-reg].
 * Location: [Institutum Patristicum Augustinianum][institute] (Augustinian Patristic Institute Conference Center)
+* Schedule: [https://2017iiifconferencethevatican.sched.com/tag/Pre-conference][pre-conf]
 
 ## IIIF Showcase: Unlocking the World's Digital Images
 The IIIF Showcase is intended for all interested parties who are new to IIIF and want to quickly get up to speed and understand the community, technology, and benefits of IIIF.
@@ -33,19 +30,20 @@ The IIIF Showcase is intended for all interested parties who are new to IIIF and
 * Registration: [https://iiif-showcase-vatican2017.eventbrite.com][showcase-reg]
 * Location: [Institutum Patristicum Augustinianum][institute] (Augustinian Patristic Institute Conference Center)
 * Capacity: 400 participants
+* Schedule: Coming Soon!
 
 ## 2017 IIIF Conference
-The Conference will include lightning talks, presentations, workshops, and discussion sessions for content curators, repository managers, software developers, administrators, and researchers from across the IIIF community. Topics of interest include: IIIF implementations, Discovery of IIIF resources, Content communities (manuscripts, newspapers, archival content, etc.), IIIF and museums, Technical specifications, IIIF-compatible software and experimentation, and On-boarding, training materials, and documentation. 
+The Conference will include lightning talks, presentations, workshops, and discussion sessions for content curators, repository managers, software developers, administrators, and researchers from across the IIIF community. Topics of interest include: IIIF implementations, Discovery of IIIF resources, Content communities (manuscripts, newspapers, archival content, etc.), IIIF and museums, Technical specifications, IIIF-compatible software and experimentation, and On-boarding, training materials, and documentation.
 
 * Dates: June 7-9, 2017
 * Registration: [https://iiif-conference-vatican2017.eventbrite.com][conference-reg]
 * Location: [Institutum Patristicum Augustinianum][institute] (Augustinian Patristic Institute Conference Center)
 * Capacity: 200 participants
+* Schedule: [https://2017iiifconferencethevatican.sched.com/][conf-sched]
 
+The IIIF [Code of Conduct][conduct] applies to all IIIF events and related activities. The IIIF Conference activities will be conducted in English. Please direct any questions to Sheila Rabun, IIIF Community and Communications Officer, at srabun@iiif.io.
 
-The IIIF [Code of Conduct][conduct] applies to all IIIF events and related activities. Please direct any questions to Sheila Rabun, IIIF Community and Communications Officer, at srabun@iiif.io.
-
-*Last updated February 27, 2017*
+*Last updated March 27, 2017*
 
 
 [home-page]: http://iiif.io/
@@ -58,3 +56,5 @@ The IIIF [Code of Conduct][conduct] applies to all IIIF events and related activ
 [conference-reg]: https://iiif-conference-vatican2017.eventbrite.com
 [mirador]: http://projectmirador.org
 [uv]: https://digirati.com/technology/our-solutions/universal-viewer/
+[pre-conf]: https://2017iiifconferencethevatican.sched.com/tag/Pre-conference
+[conf-sched]: https://2017iiifconferencethevatican.sched.com/

--- a/source/event/index.md
+++ b/source/event/index.md
@@ -12,11 +12,11 @@ All IIIF events are subject to the [Code of Conduct][conduct].
 
 __Upcoming Events__
 
-* Winter 2017: [Edinburgh][edinburgh], Scotland
 * Spring 2017: [The Vatican][vatican]
 
 __Previous Events__
 
+* Winter 2017: [Edinburgh][edinburgh], Scotland
 * Fall 2016: [The Hague][hague], Netherlands
 * Spring 2016: [New York City][nyc], USA
 * Winter 2015: [Ghent][ghent], Belgium


### PR DESCRIPTION
Added links to Sched - first iteration includes primarily parallel sessions. Tuesday schedule and Wed. Lightning Talks + Demo session details to be added asap. Also will be adding sponsors info asap.

http://vatican_schedule.iiif.io/event/2017/vatican/

Also moved Edinburgh event down: http://vatican_schedule.iiif.io/event/

