### PR TITLE
added content from museums group faqs

### DIFF
--- a/source/community/faq/index.md
+++ b/source/community/faq/index.md
@@ -51,17 +51,17 @@ IIIF allows for:
  * [Authentication API][auth]
  * In Progress: [IIIF for Audio/Visual materials][av]
 
-##  How does IIIF relate to my current, internal interoperability layer?
+##  How do the IIIF APIs relate to my current, internal interoperability layer?
 
-* Some institutions implement IIIF using a shim, or translation layer, on top of their existing interoperability layer.  In other cases, IIIF is implemented without dependencies on existing services. IIIF provides for different levels of compliance, beginning with the IIIF Image API. For more information, please see [IIIF technical details][tech-details].  
+* Some institutions implement IIIF using shims, or translation layers, on top of their existing interoperability layer.  In other cases, IIIF is implemented without dependencies on existing services. IIIF provides for different levels of compliance, beginning with the IIIF Image API. For more information, please see [IIIF technical details][tech-details].  
 
 ## Does IIIF replace or integrate with my Digital Asset Management (DAM) software?
 
-* IIIF is a method for delivery of assets, not storage. Integration with your DAM software is dependent on your DAM provider. The IIIF community is currently in the midst of asking popular DAMS providers to support IIIF.
+* IIIF is a method for delivery of assets, not storage. Integration with your DAM software is dependent on your DAM provider. The IIIF community encourages DAM software providers to incorporate native IIIF support into their products.
 
-## Is IIIF an aggregator?
+## Does the IIIF Consortium serve as an aggregator of IIIF content?
 
-* No, IIIF does not aggregate content.  IIIF defines APIs that allow for interoperability between digital image repositories.  Because these APIs are well documented and understood, use of IIIF can enable aggregators such as DPLA and Europeana to access your images more easily.  
+* No, the IIIF Consortium and wider community does not have a single aggregation platform for content.  IIIF defines APIs that allow for interoperability between digital image repositories, including aggregators.  Because the IIIF APIs are well documented and understood, use of IIIF can enable aggregators such as Artstor, DPLA, and Europeana to access your images more easily.  
 
 [search]: /api/search/
 [presentation]: /api/presentation/
@@ -74,4 +74,4 @@ IIIF allows for:
 [wadm]: https://www.w3.org/TR/2017/REC-annotation-model-20170223/
 [conduct]: /event/conduct/
 [av]: /community/groups/av/
-[tech-details]: http://iiif.io/technical-details/
+[tech-details]: /technical-details/

--- a/source/community/faq/index.md
+++ b/source/community/faq/index.md
@@ -39,6 +39,10 @@ IIIF allows for:
 
 * The IIIF Community encompasses a large and growing group of interested and active individuals and organizations dedicated to leading and sustaining the IIIF. As a community-driven initiative, IIIF thrives on active discussion, input, and feedback from a wide array of diverse individuals from libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to get involved. Participants in all IIIF activities are expected to follow the IIIF [code of conduct][conduct]. The [list of known IIIF community participants][community-list] is always growing. Additionally, the IIIF Consortium (IIIF-C) provides sustainability and steering for the initiative. For more information about the IIIF-C, see the [Consortium page][iiif-c] and [IIIF-C FAQ][iiifc-faq].
 
+## How can I participate in the IIIF Community?
+
+* Please see the [IIIF Community page][community-list] for details on how to get involved.
+
 ## What are the current IIIF specifications?
 
  * [Image API][image]
@@ -46,6 +50,18 @@ IIIF allows for:
  * [Content Search API][search]
  * [Authentication API][auth]
  * In Progress: [IIIF for Audio/Visual materials][av]
+
+##  How does IIIF relate to my current, internal interoperability layer?
+
+* Some institutions implement IIIF using a shim, or translation layer, on top of their existing interoperability layer.  In other cases, IIIF is implemented without dependencies on existing services. IIIF provides for different levels of compliance, beginning with the IIIF Image API. For more information, please see [IIIF technical details][tech-details].  
+
+## Does IIIF replace or integrate with my Digital Asset Management (DAM) software?
+
+* IIIF is a method for delivery of assets, not storage. Integration with your DAM software is dependent on your DAM provider. The IIIF community is currently in the midst of asking popular DAMS providers to support IIIF.
+
+## Is IIIF an aggregator?
+
+* No, IIIF does not aggregate content.  IIIF defines APIs that allow for interoperability between digital image repositories.  Because these APIs are well documented and understood, use of IIIF can enable aggregators such as DPLA and Europeana to access your images more easily.  
 
 [search]: /api/search/
 [presentation]: /api/presentation/
@@ -58,3 +74,4 @@ IIIF allows for:
 [wadm]: https://www.w3.org/TR/2017/REC-annotation-model-20170223/
 [conduct]: /event/conduct/
 [av]: /community/groups/av/
+[tech-details]: http://iiif.io/technical-details/

--- a/source/community/groups/museums/index.md
+++ b/source/community/groups/museums/index.md
@@ -5,6 +5,19 @@ tags: []
 cssversion: 2
 ---
 
+## About
+
+Several museums have started to adopt IIIF for their digitized collections, including the Art Gallery of Ontario, the Art Institute of Chicago, the Carnegie Museum of Art, the Cooper Hewitt Smithsonian Design Museum, the Frick Collection, the J. Paul Getty Trust, Harvard Art Museums, the Hill Museum and Manuscript Library (HMML), the National Gallery of Art, the Paul Mellon Centre, and the Yale Center for British Art.
+
+As museums across the globe continue to make digital images available online, the implications and benefits of IIIF for the museums community are increasingly clear: 
+
+* **System flexibility and easy re-use of images:** Using IIIF within your institution allows for dynamic creation of derivatives as well as copying, re-using, and sharing images and regions of interest within an image. IIIF-compatible image servers can dynamically create derivatives of original images or regions of images, avoiding the need to store multiple derivatives locally.
+* **Open Access and Authentication:** As more museums offer digital image content under an Open Access policy, IIIF allows institutions to deliver open content on the web in a common way, facilitating cross-collaboration within and between multiple institutions. Such openness can be reached through tools that support IIIF, such as Mirador for scholarly research, or the ability to easily embed content from multiple repositories in the same site. For restricted content, the IIIF Authentication API provides a mechanism for user authentication with IIIF images.
+* **Creating diverse and interactive exhibits:** Thanks to its visualization features and image manipulation functionality, IIIF-compatible solutions can deliver various means of displaying content (definition, zoom, quality), and therefore extend the possibilities offered to enhance user experience on a broader level. Image viewing clients that support IIIF offer the ability to create dynamic, interactive digital exhibits, using IIIF images from across repositories.
+* For more details on the general benefits of IIIF and more, see the **[IIIF FAQ][iiif-faq]**.
+
+## Purpose
+
 The IIIF Museums Community Group was formed in order to facilitate the discussion of museum-specific topics in relation to IIIF, including:
 
   * Mutual assistance with technical infrastructure issues related to IIIF adoption
@@ -42,5 +55,6 @@ The IIIF Museums Community Group was formed in order to facilitate the discussio
   [https://bluejeans.com/100103152]: https://bluejeans.com/100103152
   [iiif-calendar]: http://iiif.io/community/groups/
   [international-bluejeans]: https://bluejeans.com/numbers?ll=en
+  [iiif-faq]: /community/faq/
 
 {% include acronyms.md %}


### PR DESCRIPTION
http://museums_faq.iiif.io/community/groups/museums/
- added "About" and "Purpose" sections per other community group pages
- About section includes list of museums working with IIIF, and benefits/implications for museums generated by museums group
- links to general FAQ

http://museums_faq.iiif.io/community/faq/
- added some Qs that were generated in museums group, but apply to more than just museums

Notes: this is first iteration. template examples/info about IIIF at specific museums will likely take a bit longer to finalize and get online. Additional general FAQs will be added later, need to launch community effort to flesh out.

@mikeapp @azaroth42 feedback welcome. 