### PR TITLE
added Art Institute of Chicago to DAMS letter

### DIFF
--- a/source/_posts/2017-05-01-letter-to-dams.md
+++ b/source/_posts/2017-05-01-letter-to-dams.md
@@ -31,6 +31,7 @@ Thank you for your consideration.
 Sincerely,
 
 * The Andy Warhol Museum, Pittsburgh, Pennsylvania, US
+* The Art Institute of Chicago, Chicago, Illinois, US
 * Balboa Park Online Collaborative, San Diego, California, US
 * Bodleian Libraries, University of Oxford, Oxford, UK
 * Boston Public Library, Boston, Massachusetts, US


### PR DESCRIPTION
last minute addition to DAMS letter: http://aic_damsletter.iiif.io/news/2017/05/01/letter-to-dams/ @azaroth42 @mikeapp 