### PR TITLE
added sponsor 4science to vatican info

### DIFF
--- a/source/_posts/2017-04-12-vatican-conference.md
+++ b/source/_posts/2017-04-12-vatican-conference.md
@@ -49,6 +49,7 @@ Schedule information for the Conference is available via [Sched][conf-sched]. Th
 * [OCLC][oclc] - Silver Sponsor
 * [Synaptica][synaptica] - Silver Sponsor
 * [Zegami][zegami] - Silver Sponsor
+* [4Science][4science] - Silver Sponsor
 
 Please see the [Call for Sponsors][vatican-sponsors] for more information, or to become a sponsor.
 
@@ -71,3 +72,4 @@ For more event information, please see the [Vatican event page][vatican]. Questi
 [synaptica]: http://www.synaptica.com/
 [zegami]: https://zegami.com/
 [vatican-sponsors]: /event/2017/vatican-sponsors
+[4science]: http://www.4science.it/en/iiif-image-viewer/

--- a/source/event/2017/vatican.md
+++ b/source/event/2017/vatican.md
@@ -53,10 +53,9 @@ The 2017 IIIF Conference is sponsored by:
 * [OCLC][oclc] - Silver Sponsor
 * [Synaptica][synaptica] - Silver Sponsor
 * [Zegami][zegami] - Silver Sponsor
+* [4Science][4science] - Silver Sponsor
 
 Please see the [Call for Sponsors][vatican-sponsors] for more information, or to become a sponsor.
-
-*Last updated April 12, 2017*
 
 
 [home-page]: http://iiif.io/
@@ -79,3 +78,4 @@ Please see the [Call for Sponsors][vatican-sponsors] for more information, or to
 [synaptica]: http://www.synaptica.com/
 [zegami]: https://zegami.com/
 [showcase]: https://2017iiifconferencethevatican.sched.com/tag/Showcase
+[4science]: http://www.4science.it/en/iiif-image-viewer/


### PR DESCRIPTION
new sponsor - see http://sponsor_4science.iiif.io/news/2017/04/12/vatican-conference/ and http://sponsor_4science.iiif.io/event/2017/vatican/