### PR TITLE
deleted spaces in zoom url

### DIFF
--- a/source/community/call/index.md
+++ b/source/community/call/index.md
@@ -12,7 +12,7 @@ The IIIF community calls alternate between a technical and community focus, prov
   * **Regular Call Schedule:** Every other week on Wednesdays at 12:00pm Eastern - see [IIIF Community Calendar][iiif-calendar] for dates
   * **Communication Channels:** Meeting agenda and reminders are announced on the [IIIF-Discuss][iiif-discuss] email list
   * **Call Notes:** [Community Call Notes folder][comm-notes]
-  * **Call Connection Information:** Connect Online at [  https://stanford.zoom.us/j/356715389][  https://stanford.zoom.us/j/356715389] or by Phone: see [international numbers][international-zoom] - Enter Meeting ID: 356715389, and Participant ID: #
+  * **Call Connection Information:** Connect Online at [https://stanford.zoom.us/j/356715389][https://stanford.zoom.us/j/356715389] or by Phone: see [international numbers][international-zoom] - Enter Meeting ID: 356715389, and Participant ID: #
 
 
 


### PR DESCRIPTION
@zimeon there was a slight issues with the comm call url. should be fixed now at http://comm_call.iiif.io/community/call/