### PR TITLE
fixed link for SLU Ong center

### DIFF
--- a/source/_data/institutions.yml
+++ b/source/_data/institutions.yml
@@ -284,7 +284,7 @@
   uri: https://digital.library.villanova.edu/
   iiifc:
 - name: Walter J. Ong, S.J. Center for Digital Humanities at Saint Louis University
-  uri: https://www.slu.edu/the-ong-center
+  uri: https://www.slu.edu/center-for-digital-humanities
   iiifc: 2
 - name: The Walters Art Museum
   uri: http://thewalters.org

--- a/source/_posts/2017-08-30-newsletter.md
+++ b/source/_posts/2017-08-30-newsletter.md
@@ -276,7 +276,7 @@ Sheila Rabun, IIIF Community and Communications Officer
 [digipalooza]: https://digipalooza.com/
 [mec]: http://music-encoding.org/community/conference/
 [bl-poc]: https://dev.filmicweb.org/clients/digirati/iiif-av-bl/
-[slu]: https://www.slu.edu/the-ong-center
+[slu]: https://www.slu.edu/center-for-digital-humanities
 [avalon-demo]: https://avalonmediasystem.github.io/avalon-poc-standalone/build/
 [presi3]: http://prezi3.iiif.io/api/presentation/3.0
 [discovery-group]: http://iiif.io/community/groups/discovery/


### PR DESCRIPTION
I had the wrong link for SLU. It's correct now.

http://slu-linkfix.iiif.io/community/

http://slu-linkfix.iiif.io/news/2017/08/30/newsletter/