### PR TITLE
Make image validator test images explicitly CC0

### DIFF
--- a/source/api/image/validator/download.html
+++ b/source/api/image/validator/download.html
@@ -20,6 +20,7 @@ redirect_from:
 			<li><a href="/api/image/validator/67352ccc-d1b0-11e1-89ae-279075081939.png" target="new">Download PNG Image</a></li>
 			<li><a href="/api/image/validator/67352ccc-d1b0-11e1-89ae-279075081939.jp2" target="new">Download JP2 Image</a></li>
 		</ul>
+		<p>The test images may be freely reused under <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>.</p>
 	</div>
 
 <br/><hr/>


### PR DESCRIPTION
From @cbeer comment on Slack, the license isn't clear.