### PR TITLE
Remove duplicate JSON keys 'height' and 'width' from combined-context.json

### DIFF
--- a/source/api/presentation/3/combined-context.json
+++ b/source/api/presentation/3/combined-context.json
@@ -94,12 +94,6 @@
       "@type": "@vocab",
       "@id": "doap:implements"
     },
-    "height": {
-      "@id": "exif:height"
-    },
-    "width": {
-      "@id": "exif:width"
-    },
     "duration": {
       "@id": "ebu:duration"
     },


### PR DESCRIPTION
`source/api/presentation/3/combined-context.json` contains two appearances of `width` and `height`:

https://github.com/IIIF/api/blob/7c686d3c9b4f7f9d9bee319897164a71ea1aa6eb/source/api/presentation/3/combined-context.json#L97-L102

https://github.com/IIIF/api/blob/7c686d3c9b4f7f9d9bee319897164a71ea1aa6eb/source/api/presentation/3/combined-context.json#L201-L208

While this is still technically valid JSON and is of no consequence in at least JavaScript and PHP,

- [the JSON LD spec draft](https://www.w3.org/2018/jsonld-cg-reports/json-ld/#terminology) states that a JSON key must be unique in JSON-LD
- any implementation of the [JSON-LD API Create Term Definition algorithm](https://www.w3.org/2018/jsonld-cg-reports/json-ld-api/#algorithm-0) in a language that interprets duplicate JSON keys as separate entries in the order of their appearance will ignore the `@type` definition (see the first item in 4.2.2 of the linked document)